### PR TITLE
ci: bump poetry

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10"]
-        poetry-version: ["1.1.12"]
+        poetry-version: ["1.7.0"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
![image](https://github.com/novem-code/novem-python/assets/689179/a8439418-754f-4c17-95b7-2910fabc62dc)

The lockfile from #2 was too modern for the (inexplicably) ancient `poetry` used for the github action, so bump it.