### PR TITLE
bsn/release workflow update

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,7 +29,7 @@ jobs:
         poetry build
 
     - name: Storage wheel
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: python-wheel
         path: dist/
@@ -45,7 +45,7 @@ jobs:
       id-token: write
     steps:
     - name: Retrieve wheel
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: python-wheel
         path: dist/


### PR DESCRIPTION
- **release: bump version**
- **release: the upload-artifact@v2 workflow is deprecated, so upgrade to v4**
