### PR TITLE
bsn/release workflow update 2

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,9 +9,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install Poetry
       uses: abatilo/actions-poetry@v2


### PR DESCRIPTION
- **release: bump version**
- **release: the upload-artifact@v2 workflow is deprecated, so upgrade to v4**
- **workflow: quote the python-version to avoid it being parsed as float**
