### PR TITLE
pylib-format: add utility function for merge grammar

### DIFF
--- a/novem/table/utils/__init__.py
+++ b/novem/table/utils/__init__.py
@@ -1,0 +1,3 @@
+from novem.table.utils.format import merge_from_index
+
+__all__ = ["merge_from_index"]

--- a/novem/table/utils/format.py
+++ b/novem/table/utils/format.py
@@ -1,0 +1,84 @@
+from typing import List, Optional, Union
+
+import pandas as pd
+
+
+def merge_from_index(src: Union[pd.DataFrame, pd.Index], io: Optional[int] = None) -> str:
+    """
+    Create novem merge instructions based on a supplied pandas DataFrame or Index object.
+
+    This function analyzes the structure of the input DataFrame or Index and generates
+    a set of merge instructions. These instructions describe how to merge cells to
+    replicate the hierarchical structure of the input in a tabular format.
+    Single cell merges are skipped.
+
+    Args:
+        src (Union[pd.DataFrame, pd.Index]): The source DataFrame or Index object to analyze.
+        io (Optional[int]): Initial offset. If provided, overrides the calculated offset.
+            Use this to account for additional header rows.
+
+    Returns:
+        str: A string of newline-separated merge instructions. Each instruction has the format:
+             "start:end column label"
+             where:
+             - start:end is the range of rows to merge
+             - column is the column index
+             - label is a unique identifier for the merged cell
+
+    Raises:
+        TypeError: If src is not a pandas DataFrame or Index object.
+
+    Example:
+        >>> import pandas as pd
+        >>> df = pd.DataFrame(index=[['A', 'A', 'B', 'B', 'C'],
+        ...                          ['X', 'Y', 'Z', 'W', 'V']])
+        >>> print(merge_from_index(df))
+        1:2 0 lbl1
+        3:4 0 lbl2
+        >>>
+        >>> # Using a MultiIndex directly
+        >>> idx = pd.MultiIndex.from_product([['P', 'Q'], ['1', '2', '3']])
+        >>> print(merge_from_index(idx))
+        1:3 0 lbl1
+        4:6 0 lbl2
+        >>>
+        >>> # Using a custom initial offset
+        >>> print(merge_from_index(df, io=2))
+        2:3 0 lbl1
+        4:5 0 lbl2
+    """
+    if not isinstance(src, (pd.DataFrame, pd.Index)):
+        raise TypeError("Input must be a pandas DataFrame or Index object")
+
+    if isinstance(src, pd.DataFrame):
+        index = src.index
+        aio = src.columns.nlevels
+    else:
+        index = src
+        aio = 1
+
+    if io is not None:
+        aio = io
+
+    if not isinstance(index, pd.MultiIndex):
+        index = pd.MultiIndex.from_arrays([index])
+
+    if len(index) == 0:
+        return ""  # Return empty string for empty index
+
+    merge_instructions: List[str] = []
+    for level in range(index.nlevels):
+        current_label = None
+        start_row = 0
+        for row, label in enumerate(index.get_level_values(level)):
+            if label != current_label:
+                if current_label is not None and start_row < row - 1:
+                    merge_instructions.append(
+                        f"{start_row + aio}:{row + aio - 1} {level} lbl{len(merge_instructions) + 1}"
+                    )
+                current_label = label
+                start_row = row
+        if start_row < row:
+            merge_instructions.append(f"{start_row + aio}:{row + aio} {level} lbl{len(merge_instructions) + 1}")
+
+    return "\n".join(merge_instructions)

--- a/novem/table/utils/format.py
+++ b/novem/table/utils/format.py
@@ -73,14 +73,15 @@ def merge_from_index(src: Union[pd.DataFrame, pd.Index], io: Optional[int] = Non
     for level in range(index.nlevels):
         current_label = None
         start_row = 0
+
         for row, label in enumerate(index.get_level_values(level)):
-            if label != current_label:
-                if current_label is not None and start_row < row - 1:
-                    merge_instructions.append(
-                        f"{start_row + aio}:{row + aio - 1} {level} lbl{len(merge_instructions) + 1}"
-                    )
-                current_label = label
-                start_row = row
+            if label == current_label:
+                continue
+            if current_label is not None and start_row < row - 1:
+                merge_instructions.append(f"{start_row + aio}:{row + aio - 1} {level} lbl{len(merge_instructions) + 1}")
+            current_label = label
+            start_row = row
+
         if start_row < row:
             merge_instructions.append(f"{start_row + aio}:{row + aio} {level} lbl{len(merge_instructions) + 1}")
 

--- a/novem/table/utils/format.py
+++ b/novem/table/utils/format.py
@@ -1,6 +1,9 @@
 from typing import List, Optional, Union
 
-import pandas as pd
+try:
+    import pandas as pd
+except ImportError:
+    pd = None  # type: ignore
 
 
 def merge_from_index(src: Union[pd.DataFrame, pd.Index], io: Optional[int] = None) -> str:

--- a/tests/test_table_utils.py
+++ b/tests/test_table_utils.py
@@ -1,0 +1,129 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from novem.table.utils import merge_from_index
+
+
+@pytest.fixture
+def sample_dataframe():
+    return pd.DataFrame(index=[["A", "A", "B", "B", "C"], ["X", "Y", "Z", "W", "V"]])
+
+
+@pytest.fixture
+def sample_multiindex():
+    return pd.MultiIndex.from_product([["P", "Q"], ["1", "2", "3"]])
+
+
+def test_dataframe_with_multiindex(sample_dataframe):
+    result = merge_from_index(sample_dataframe)
+    expected = "1:2 0 lbl1\n3:4 0 lbl2"
+    assert result == expected
+
+
+def test_empty_dataframe():
+    df = pd.DataFrame()
+    result = merge_from_index(df)
+    assert result == ""
+
+
+def test_dataframe_single_level_index():
+    df = pd.DataFrame(index=["A", "B", "C"])
+    result = merge_from_index(df)
+    assert result == ""
+
+
+def test_multiindex_directly(sample_multiindex):
+    result = merge_from_index(sample_multiindex)
+    expected = "1:3 0 lbl1\n4:6 0 lbl2"
+    assert result == expected
+
+
+def test_dataframe_custom_offset(sample_dataframe):
+    result = merge_from_index(sample_dataframe, io=2)
+    expected = "2:3 0 lbl1\n4:5 0 lbl2"
+    assert result == expected
+
+
+def test_single_entry_index():
+    index = pd.Index(["Single"])
+    result = merge_from_index(index)
+    assert result == ""
+
+
+def test_dataframe_alternating_values():
+    df = pd.DataFrame(index=[["A", "B", "A", "B"], ["X", "Y", "Z", "W"]])
+    result = merge_from_index(df)
+    assert result == ""
+
+
+def test_dataframe_single_column():
+    df = pd.DataFrame({"A": [1, 2, 3]}, index=[["X", "X", "Y"], ["1", "2", "3"]])
+    result = merge_from_index(df)
+    expected = "1:2 0 lbl1"
+    assert result == expected
+
+
+def test_dataframe_multiple_column_levels():
+    df = pd.DataFrame(
+        np.random.rand(4, 4),
+        columns=pd.MultiIndex.from_product([["A", "B"], ["X", "Y"]]),
+        index=pd.MultiIndex.from_product([["P", "Q"], ["1", "2"]]),
+    )
+    result = merge_from_index(df)
+    expected = "2:3 0 lbl1\n4:5 0 lbl2"
+    assert result == expected
+
+
+def test_large_multiindex():
+    large_index = pd.MultiIndex.from_product([["A", "B", "C"], ["X", "Y", "Z"], ["1", "2", "3", "4"]])
+    result = merge_from_index(large_index)
+    expected = (
+        "1:12 0 lbl1\n13:24 0 lbl2\n25:36 0 lbl3\n1:4 1 lbl4\n5:8 1 lbl5\n9:12 1 lbl6\n13:16 1 lbl7\n"
+        "17:20 1 lbl8\n21:24 1 lbl9\n25:28 1 lbl10\n29:32 1 lbl11\n33:36 1 lbl12"
+    )
+    assert result == expected
+
+
+def test_mixed_multiindex():
+    mixed_index = pd.MultiIndex.from_tuples(
+        [("A", "X", 1), ("A", "X", 2), ("A", "Y", 1), ("B", "X", 1), ("B", "Y", 1), ("B", "Y", 2)]
+    )
+    result = merge_from_index(mixed_index)
+    expected = "1:3 0 lbl1\n4:6 0 lbl2\n1:2 1 lbl3\n5:6 1 lbl4\n3:5 2 lbl5"
+    assert result == expected
+
+
+def test_invalid_input():
+    with pytest.raises(TypeError):
+        merge_from_index([1, 2, 3])
+
+
+def test_zero_initial_offset():
+    df = pd.DataFrame(index=[["A", "A", "B"], ["X", "Y", "Z"]])
+    result = merge_from_index(df, io=0)
+    expected = "0:1 0 lbl1"
+    assert result == expected
+
+
+def test_very_large_offset():
+    df = pd.DataFrame(index=[["A", "A", "B"], ["X", "Y", "Z"]])
+    result = merge_from_index(df, io=1000)
+    expected = "1000:1001 0 lbl1"
+    assert result == expected
+
+
+def test_single_level_multiindex_no_merges():
+    index = pd.MultiIndex.from_tuples([("A",), ("B",), ("C",)])
+    result = merge_from_index(index)
+    assert result == ""
+
+
+def test_all_unique_values_multiindex():
+    index = pd.MultiIndex.from_tuples([("A", "X"), ("B", "Y"), ("C", "Z")])
+    result = merge_from_index(index)
+    assert result == ""
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
This pull request adds a basic utility function to convert a pandas dataframe or index object into a corresponding [novem merge grammar](https://novem.no/docs/plot/config/table/#merge).

```python
from novem.table.utils import merge_from_index
merge_format  =  merge_from_index(xx)
```

Fixes novem-code/novem-python#26