### PR TITLE
pylib: add `df` accessor utility

### DIFF
--- a/novem/vis/plot.py
+++ b/novem/vis/plot.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from typing import Any, Dict, Optional
 
 from novem.vis import NovemVisAPI
@@ -5,6 +6,11 @@ from novem.vis import NovemVisAPI
 from .cell import NovemCellConfig
 from .colors import NovemColors
 from .plot_config import NovemPlotConfig
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = None  # type: ignore
 
 
 class Plot(NovemVisAPI):
@@ -176,8 +182,27 @@ class Plot(NovemVisAPI):
     # Interactive utility functions
     ###
 
-    def df(self, data: Any, **kwargs: Any) -> Any:
+    @property
+    def df(self) -> Any:
         """
+        Get a dataframe representation of the data for
+        this plot
+        """
+        if pd is None:
+            raise ImportError(
+                "Pandas is required for this functionality. Please install it using 'pip install pandas'."
+            )
+
+        raw_data = self._read("/data")
+
+        # Convert the CSV string to a DataFrame
+        df = pd.read_csv(StringIO(raw_data))
+
+        return df
+
+    def wdf(self, data: Any, **kwargs: Any) -> Any:
+        """
+        Wrap dataframe
         Expects a dataframe as input and returns the
         same dataframe so it can be chained
         """

--- a/novem/vis/plot.py
+++ b/novem/vis/plot.py
@@ -1,5 +1,5 @@
 from io import StringIO
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from novem.vis import NovemVisAPI
 
@@ -7,10 +7,14 @@ from .cell import NovemCellConfig
 from .colors import NovemColors
 from .plot_config import NovemPlotConfig
 
-try:
+# Import pandas for type checking, not runtime
+if TYPE_CHECKING:
     import pandas as pd
-except ImportError:
-    pd = None  # type: ignore
+else:
+    try:
+        import pandas as pd
+    except ImportError:
+        pd = None  # type: ignore
 
 
 class Plot(NovemVisAPI):
@@ -183,7 +187,7 @@ class Plot(NovemVisAPI):
     ###
 
     @property
-    def df(self) -> Any:
+    def df(self) -> "pd.DataFrame":
         """
         Get a dataframe representation of the data for
         this plot


### PR DESCRIPTION
Sometimes it's really useful to get a plot already parsed into a dataframe. This changes the unused wrapper functionality into `wdf` and uses the more natural `df` as a property to get a DataFrame representation.

Fixes novem-code/novem-python#28

**Example use case**
```ipython
In [1]: from novem import Plot

In [2]: plt = Plot('state_pop')

In [3]: plt.data
Out[3]: 'Name,Under 5 Years,5 to 14 Years,15 to 17 Years,18 to 24 Years,25 to 44 Years,45 to 64 Years,65 Years and Over\nTexas,1997007.0,4147370.0,1237105.0,3381828.0,9253970.0,6757950.0,3593369.0\nFlorida,1133390.0,2354577.0,726477.0,2108722.0,6057385.0,5573165.0,4347912.0\nNew York,1140669.0,2237295.0,693178.0,2192139.0,6089493.0,5133140.0,3221702.0\nPennsylvania,702231.0,1480368.0,466983.0,1387840.0,3661650.0,3458314.0,2335104.0\nIllinois,755518.0,1598583.0,501332.0,1427290.0,3909047.0,3293745.0,1990426.0\nCalifornia,2409082.0,5029090.0,1518469.0,4511853.0,12817044.0,9778830.0,5644497.0\n'

In [4]: plt.df
Out[4]:
           Name  Under 5 Years  5 to 14 Years  15 to 17 Years  18 to 24 Years  25 to 44 Years  45 to 64 Years  65 Years and Over
0         Texas      1997007.0      4147370.0       1237105.0       3381828.0       9253970.0       6757950.0          3593369.0
1       Florida      1133390.0      2354577.0        726477.0       2108722.0       6057385.0       5573165.0          4347912.0
2      New York      1140669.0      2237295.0        693178.0       2192139.0       6089493.0       5133140.0          3221702.0
3  Pennsylvania       702231.0      1480368.0        466983.0       1387840.0       3661650.0       3458314.0          2335104.0
4      Illinois       755518.0      1598583.0        501332.0       1427290.0       3909047.0       3293745.0          1990426.0
5    California      2409082.0      5029090.0       1518469.0       4511853.0      12817044.0       9778830.0          5644497.0
```