### PR TITLE
dev: remove `bump_version` as a script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,6 @@ typing-extensions = "^4.9.0"
 [tool.poetry.scripts]
 novem = 'novem.cli:run_cli'
 
-[tool.poetry.dev-dependencies]
-bump_version = {path = "scripts/bump_version.py"}
-
 [tool.poetry.group.dev.dependencies]
 flake8 = "^7.1.1"
 isort = "^5.13.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ typing-extensions = "^4.9.0"
 
 [tool.poetry.scripts]
 novem = 'novem.cli:run_cli'
-bump_version = 'scripts.bump_version:main'
+
+[tool.poetry.dev-dependencies]
+bump_version = {path = "scripts/bump_version.py"}
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^7.1.1"


### PR DESCRIPTION
Fixes novem-code/novem-python#31

After building and installing:
```
(venv) sondove@irenicus:~/tmp/aa$ which novem
/home/sondove/tmp/aa/venv/bin/novem
(venv) sondove@irenicus:~/tmp/aa$ which bump_version
/home/sondove/.pyenv/shims/bump_version
(venv) sondove@irenicus:~/tmp/aa$
```

New bump_version workflow: `poetry run python scripts/bump_version.py`