### PR TITLE
vis: add interactive `log` property to python class

### DIFF
--- a/novem/vis/__init__.py
+++ b/novem/vis/__init__.py
@@ -382,6 +382,15 @@ class NovemVisAPI(NovemAPI):
             print("should raise a general error")
 
     @property
+    def log(self) -> None:
+        """
+        print the current novem logs for the given vis
+        """
+        print(self.api_read("/log"))
+
+        return None
+
+    @property
     def qpr(self) -> str:
         if self._qpr:
             return self._qpr.replace("&", ",")

--- a/novem/vis/mail.py
+++ b/novem/vis/mail.py
@@ -226,10 +226,6 @@ class Mail(NovemVisAPI):
     def shortname(self) -> str:
         return self.api_read("/shortname").strip()
 
-    @property
-    def log(self) -> str:
-        return self.api_read("/log").strip()
-
     ###
     # Important attributes that cause render and sending
     ###


### PR DESCRIPTION
Similar to how `.x` and `.i` properties can be used interactively to output ansi or png versions of a visual. This adds a log endpoint that will print the latest logs.

The reason for making it a property that does a print instead of returning the string is that 99% of the use case will be `print(plt.log)` and it feels better to let the user just do `plt.log` when exploring novem interactively.

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/e7f01193-4ccb-4e41-afa9-2b1e505d3717">

Fixes novem-code/novem-python#33