### PR TITLE
env: add support for NOVEM_API_ROOT

### DIFF
--- a/novem/api_ref.py
+++ b/novem/api_ref.py
@@ -5,10 +5,13 @@ from typing import Any, Dict, Optional
 
 import requests
 
+from novem.utils import API_ROOT
+
 from .utils import get_current_config
 from .version import __version__
 
 did_token_warning = False
+did_api_root_warning = False
 
 
 def get_ua(is_cli: bool) -> Dict[str, str]:
@@ -74,6 +77,8 @@ class NovemAPI(object):
 
         # api root should always be supplied in the result
         self._api_root = config["api_root"]
+        if not self._api_root:
+            self._api_root = os.getenv("NOVEM_API_ROOT") or API_ROOT
 
         env_token = os.getenv("NOVEM_TOKEN")
         global did_token_warning

--- a/novem/api_ref.py
+++ b/novem/api_ref.py
@@ -11,7 +11,6 @@ from .utils import get_current_config
 from .version import __version__
 
 did_token_warning = False
-did_api_root_warning = False
 
 
 def get_ua(is_cli: bool) -> Dict[str, str]:

--- a/novem/cli/config.py
+++ b/novem/cli/config.py
@@ -5,7 +5,7 @@ from os import path
 from pathlib import Path
 from typing import Optional, Tuple
 
-from ..utils import get_config_path
+from ..utils import API_ROOT, get_config_path
 
 
 def update_config(
@@ -35,6 +35,8 @@ def update_config(
 
     # read our config object
     config.read(novem_config)
+
+    api_root = api_root or os.getenv("NOVEM_API_ROOT") or API_ROOT
 
     add_api_root = True
 

--- a/novem/utils.py
+++ b/novem/utils.py
@@ -120,7 +120,7 @@ def get_current_config(
     co = Config(
         {
             "token": kwargs.get("token", None),
-            "api_root": kwargs.get("api_root", API_ROOT),
+            "api_root": kwargs.get("api_root", None),
             "ignore_ssl_warn": kwargs.get("ignore_ssl", False),
         }
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,3 +29,22 @@ def test_accepts_token_from_env(requests_mock, fs):
     p = Plot(id="foo", create=False)
     assert p.url == "test-url"
     assert p.token == "test_token"
+
+
+NOVEM_API_ROOT_TEST = "https://api.novem.test/v1/"
+
+
+@patch.dict(
+    os.environ,
+    {
+        "NOVEM_TOKEN": "test_token",
+        "NOVEM_API_ROOT": NOVEM_API_ROOT_TEST,
+    },
+)
+def test_accepts_api_root_from_env(requests_mock, fs):
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo", text='{"id": "foo"}', status_code=200)
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo/url", text="test-url", status_code=200)
+
+    p = Plot(id="foo", create=False)
+    assert p.url == "test-url"
+    assert p.token == "test_token"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,34 @@ from unittest.mock import patch
 import pytest
 
 from novem import Plot
-from novem.utils import API_ROOT
+from novem.utils import API_ROOT, get_config_path
+
+
+def setup_fake_config(fs, token, api_root):
+    """Set up a fake novem.conf file in the virtual filesystem"""
+    # Create the config directory
+    config_dir, config_path = get_config_path()
+    fs.create_dir(config_dir)
+
+    # Create the config file with the specified content
+    config_content = f"""[general]
+api_root = {api_root}
+profile = demo
+
+[profile:demo]
+username = sondov
+token_name = test-token-name
+token = {token}
+
+[app:cli]
+
+[app:python]
+
+[app:fuse]"""
+
+    fs.create_file(config_path, contents=config_content)
+
+    return config_path
 
 
 def test_fails_without_token(requests_mock, fs):
@@ -46,5 +73,87 @@ def test_accepts_api_root_from_env(requests_mock, fs):
     requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo/url", text="test-url", status_code=200)
 
     p = Plot(id="foo", create=False)
+    assert p.url == "test-url"
+    assert p.token == "test_token"
+
+
+@patch.dict(os.environ, {"NOVEM_TOKEN": "test_token"})
+def test_accepts_api_root_from_kwargs(requests_mock, fs):
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo", text='{"id": "foo"}', status_code=200)
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo/url", text="test-url", status_code=200)
+
+    p = Plot(id="foo", api_root=NOVEM_API_ROOT_TEST, create=False)
+    assert p.url == "test-url"
+    assert p.token == "test_token"
+
+
+def test_accepts_api_root_from_config(requests_mock, fs):
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo", text='{"id": "foo"}', status_code=200)
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo/url", text="test-url", status_code=200)
+
+    setup_fake_config(fs, "test_token", NOVEM_API_ROOT_TEST)
+
+    p = Plot(id="foo", create=False)
+    assert p.url == "test-url"
+    assert p.token == "test_token"
+
+
+@patch.dict(
+    os.environ,
+    {
+        "NOVEM_TOKEN": "test_token",
+        "NOVEM_API_ROOT": "https://this.is.wrong.com/v1/",
+    },
+)
+def test_accepts_api_root_from_kwargs_over_env(requests_mock, fs):
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo", text='{"id": "foo"}', status_code=200)
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo/url", text="test-url", status_code=200)
+
+    p = Plot(id="foo", api_root=NOVEM_API_ROOT_TEST, create=False)
+    assert p.url == "test-url"
+    assert p.token == "test_token"
+
+
+def test_accepts_api_root_from_kwargs_over_config(requests_mock, fs):
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo", text='{"id": "foo"}', status_code=200)
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo/url", text="test-url", status_code=200)
+
+    setup_fake_config(fs, "test_token", API_ROOT)
+
+    p = Plot(id="foo", api_root=NOVEM_API_ROOT_TEST, create=False)
+    assert p.url == "test-url"
+    assert p.token == "test_token"
+
+
+@patch.dict(
+    os.environ,
+    {
+        "NOVEM_API_ROOT": "https://this.is.wrong.com/v1/",
+    },
+)
+def test_accepts_api_root_from_config_over_env(requests_mock, fs):
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo", text='{"id": "foo"}', status_code=200)
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo/url", text="test-url", status_code=200)
+
+    setup_fake_config(fs, "test_token", NOVEM_API_ROOT_TEST)
+
+    p = Plot(id="foo", create=False)
+    assert p.url == "test-url"
+    assert p.token == "test_token"
+
+
+# Test that kwarg > env
+@patch.dict(
+    os.environ,
+    {
+        "NOVEM_TOKEN": "test_token",
+        "NOVEM_API_ROOT": "https://this.is.wrong.com/v1/",
+    },
+)
+def test_accepts_api_root_from_kwarg_over_env(requests_mock, fs):
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo", text='{"id": "foo"}', status_code=200)
+    requests_mock.register_uri("get", f"{NOVEM_API_ROOT_TEST}vis/plots/foo/url", text="test-url", status_code=200)
+
+    p = Plot(id="foo", api_root=NOVEM_API_ROOT_TEST, create=False)
     assert p.url == "test-url"
     assert p.token == "test_token"


### PR DESCRIPTION
Sometimes you want to test your code against a different api or endpoint. This commit adds support for a NOVEM_API_ROOT endpoint.

This fixes novem-code/novem-python#46