### PR TITLE
vis: add utility accessors for custom visualisations

### DIFF
--- a/novem/vis/custom.py
+++ b/novem/vis/custom.py
@@ -10,28 +10,16 @@ class NovemCustom:
 
     @property
     def js(self) -> str:
-        """
-        get the custom JS
-        """
         return self.api._read("/config/custom/custom.js")
 
     @js.setter
     def js(self, value: str) -> None:
-        """
-        Set the custom JS
-        """
         return self.api._write("/config/custom/custom.js", value)
 
     @property
     def css(self) -> str:
-        """
-        get the custom CSS
-        """
         return self.api._read("/config/custom/custom.css")
 
     @css.setter
     def css(self, value: str) -> None:
-        """
-        Set the custom CSS
-        """
         return self.api._write("/config/custom/custom.css", value)

--- a/novem/vis/custom.py
+++ b/novem/vis/custom.py
@@ -1,12 +1,13 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from novem.vis.plot import Plot
 
 
+@dataclass
 class NovemCustom:
-    def __init__(self, api: "Plot") -> None:
-        self.api: "Plot" = api
+    api: "Plot"
 
     @property
     def js(self) -> str:

--- a/novem/vis/custom.py
+++ b/novem/vis/custom.py
@@ -1,0 +1,37 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from novem.vis.plot import Plot
+
+
+class NovemCustom:
+    def __init__(self, api: "Plot") -> None:
+        self.api: "Plot" = api
+
+    @property
+    def js(self) -> str:
+        """
+        get the custom JS
+        """
+        return self.api._read("/config/custom/custom.js")
+
+    @js.setter
+    def js(self, value: str) -> None:
+        """
+        Set the custom JS
+        """
+        return self.api._write("/config/custom/custom.js", value)
+
+    @property
+    def css(self) -> str:
+        """
+        get the custom CSS
+        """
+        return self.api._read("/config/custom/custom.css")
+
+    @css.setter
+    def css(self, value: str) -> None:
+        """
+        Set the custom CSS
+        """
+        return self.api._write("/config/custom/custom.css", value)

--- a/novem/vis/plot.py
+++ b/novem/vis/plot.py
@@ -5,6 +5,7 @@ from novem.vis import NovemVisAPI
 
 from .cell import NovemCellConfig
 from .colors import NovemColors
+from .custom import NovemCustom
 from .plot_config import NovemPlotConfig
 
 # Import pandas for type checking, not runtime
@@ -23,6 +24,7 @@ class Plot(NovemVisAPI):
     """
 
     colors: Optional[NovemColors] = None
+    custom: Optional[NovemCustom] = None
     cell: Optional[NovemCellConfig] = None
     config: Optional[NovemPlotConfig] = None
 
@@ -53,6 +55,7 @@ class Plot(NovemVisAPI):
         self._pending: Dict[str, str] = {}
 
         self.colors = NovemColors(self)
+        self.custom = NovemCustom(self)
         self.cell = NovemCellConfig(self)
         self.config = NovemPlotConfig(self)
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -13,11 +13,9 @@ to_csv_test_string = "the to_csv function was invoked"
 
 class TestFrame(object):
     def to_csv(self):
-        # simple test class to make sure that the novem library invokes to_csv.
         return to_csv_test_string
 
     def pipe(self, func, **kwargs):
-        # utility function to simulate dataframe df.call
         func(self, **kwargs)
 
 
@@ -27,19 +25,15 @@ def test_plot(requests_mock):
     plot_name = "long test name"
     plot_description = "long test description"
     plot_caption = "plot caption is nice to have"
+    custom_js = "function test() { return 'test'; }"
+    custom_css = ".test { color: red; }"
 
-    # grab our base path so we can use it for our test config
     base = os.path.dirname(os.path.abspath(__file__))
     config_file = f"{base}/test.conf"
 
-    # read our config file as well
     config = configparser.ConfigParser()
-
-    # check if novem config file exist
     config.read(config_file)
     api_root = config["general"]["api_root"]
-
-    # need to verify that assertions are called
 
     gcheck = {
         "create": False,
@@ -48,79 +42,135 @@ def test_plot(requests_mock):
         "name": False,
         "caption": False,
         "data": False,
+        "custom_js_read": False,
+        "custom_js_write": False,
+        "custom_css_read": False,
+        "custom_css_write": False,
     }
 
-    def verify(key, val, request, context):
+    def verify_write(key, val, request, context):
         gcheck[key] = True
         assert request.text == val
+        return ""
 
-    def verify_put(key, val, request, context):
+    def verify_read(key, val, request, context):
         gcheck[key] = True
-        assert request.url == f"{api_root}vis/plots/{plot_id}"
+        return val
 
+    def verify_create(request, context):
+        gcheck["create"] = True
+        return ""
+
+    # Plot creation endpoint
     requests_mock.register_uri(
         "put",
         f"{api_root}vis/plots/{plot_id}",
-        text=partial(verify_put, "create", plot_type),
+        text=verify_create,
     )
 
     requests_mock.register_uri(
         "post",
         f"{api_root}vis/plots/{plot_id}/config/type",
-        text=partial(verify, "type", plot_type),
+        text=partial(verify_write, "type", plot_type),
     )
 
     requests_mock.register_uri(
         "post",
         f"{api_root}vis/plots/{plot_id}/config/caption",
-        text=partial(verify, "caption", plot_caption),
+        text=partial(verify_write, "caption", plot_caption),
     )
 
     requests_mock.register_uri(
         "post",
         f"{api_root}vis/plots/{plot_id}/name",
-        text=partial(verify, "name", plot_name),
+        text=partial(verify_write, "name", plot_name),
     )
 
     requests_mock.register_uri(
         "post",
         f"{api_root}vis/plots/{plot_id}/description",
-        text=partial(verify, "desc", plot_description),
+        text=partial(verify_write, "desc", plot_description),
+    )
+
+    # Custom JS endpoints
+    requests_mock.register_uri(
+        "get",
+        f"{api_root}vis/plots/{plot_id}/config/custom/custom.js",
+        text=partial(verify_read, "custom_js_read", custom_js),
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}vis/plots/{plot_id}/data",
-        text=partial(verify, "data", to_csv_test_string),
+        f"{api_root}vis/plots/{plot_id}/config/custom/custom.js",
+        text=partial(verify_write, "custom_js_write", custom_js),
     )
 
-    # create a novem api object
+    # Custom CSS endpoints
+    requests_mock.register_uri(
+        "get",
+        f"{api_root}vis/plots/{plot_id}/config/custom/custom.css",
+        text=partial(verify_read, "custom_css_read", custom_css),
+    )
+
+    requests_mock.register_uri(
+        "post",
+        f"{api_root}vis/plots/{plot_id}/config/custom/custom.css",
+        text=partial(verify_write, "custom_css_write", custom_css),
+    )
+
+    # Data endpoints
+    requests_mock.register_uri(
+        "post",
+        f"{api_root}vis/plots/{plot_id}/data",
+        text=partial(verify_write, "data", to_csv_test_string),
+    )
+
+    # Create plot instance
     n = Plot(
         plot_id,
         type=plot_type,
-        config_path=config_file,  # config location
+        config_path=config_file,
         caption=plot_caption,
     )
 
-    # set plot name
+    # Test basic properties
     n.name = plot_name
     n.description = plot_description
 
-    tf = TestFrame()
+    # Test custom properties
+    # Test reading custom.js
+    js_content = n.custom.js
+    assert js_content == custom_js
+    assert gcheck["custom_js_read"] is True
 
-    # n should call /data endpoint with content of tf.to_string
+    # Test writing custom.js
+    n.custom.js = custom_js
+    assert gcheck["custom_js_write"] is True
+
+    # Test reading custom.css
+    css_content = n.custom.css
+    assert css_content == custom_css
+    assert gcheck["custom_css_read"] is True
+
+    # Test writing custom.css
+    n.custom.css = custom_css
+    assert gcheck["custom_css_write"] is True
+
+    # Test data
+    tf = TestFrame()
     tf.pipe(n)
 
     lit_str = "A literal string also works"
     requests_mock.register_uri(
         "post",
         f"{api_root}vis/plots/{plot_id}/data",
-        text=partial(verify, "data", lit_str),
+        text=partial(verify_write, "data", lit_str),
     )
     n.data = lit_str
 
+    # Verify all operations were performed
     for k, v in gcheck.items():
-        assert v is True
+        assert v is True, f"Operation {k} was not performed"
 
     assert n._api_root == "https://api.novem.no/v1/"
 
@@ -132,13 +182,9 @@ def test_plot_log(requests_mock, fs):
 
     p = Plot(id="foo", create=False)
 
-    # Redirect stdout to a StringIO object
     f = io.StringIO()
     with redirect_stdout(f):
         p.log
 
-    # Get the printed output
     output = f.getvalue().strip()
-
-    # Assert that the output matches the expected string
     assert output == "log_test_plot"


### PR DESCRIPTION
Novem offers custom visuals where the user can specify their own css and js code. Here we add some convenient utility functions that are consistent with how other novem api cases such as `colors` and `shared` are used.

Fixes novem-code/novem-python#43