### PR TITLE
github: Add pretty names to publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,9 +1,12 @@
+name: Python Publish
+
 on:
   release:
     types: [created]
 
 jobs:
   install-test-and-build:
+    name: Install, test & build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -36,6 +39,7 @@ jobs:
         retention-days: 1
 
   publish:
+    name: Publish
     runs-on: ubuntu-latest
     needs: install-test-and-build
     environment:


### PR DESCRIPTION
I can't help but think this doesn't look as good as it should in the workflow overview:

![image](https://github.com/user-attachments/assets/5f0bdef0-7a77-4008-a8da-2d163c32a1b6)
