### PR TITLE
mail: make sure empty recipient messages are sent

### DIFF
--- a/novem/vis/mail.py
+++ b/novem/vis/mail.py
@@ -264,7 +264,7 @@ class Mail(NovemVisAPI):
 
     @to.setter
     def to(self, value: Union[str, List[str]]) -> None:
-        if not value:
+        if value is None:
             return
         if isinstance(value, list):
             value = self._r2s(value)
@@ -278,7 +278,7 @@ class Mail(NovemVisAPI):
 
     @cc.setter
     def cc(self, value: Union[str, List[str]]) -> None:
-        if not value:
+        if value is None:
             return
         if isinstance(value, list):
             value = self._r2s(value)
@@ -292,7 +292,7 @@ class Mail(NovemVisAPI):
 
     @bcc.setter
     def bcc(self, value: Union[str, List[str]]) -> None:
-        if not value:
+        if value is None:
             return
         if isinstance(value, list):
             value = self._r2s(value)

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -391,9 +391,31 @@ def test_mail_recipients_to(requests_mock):
         ],
     }
     m = setup_mail_mock(requests_mock, conf)
+
     m.to = ["@novem_demo", "@test"]
     assert m.to == "@novem_demo\n@test"
+
     m.to = "@novem_demo\n@test"
+    assert m.to == "@novem_demo\n@test"
+
+    conf = {
+        "mail_id": "test_mail",
+        "reqs": [
+            [
+                "get",
+                "/recipients/to",
+                "",
+            ],
+            ["post", "/recipients/to", None],
+        ],
+    }
+    m = setup_mail_mock(requests_mock, conf)
+
+    m.to = ""
+    assert m.to == ""
+
+    m.to = []
+    assert m.to == ""
 
 
 def test_mail_recipients_cc(requests_mock):
@@ -413,9 +435,35 @@ def test_mail_recipients_cc(requests_mock):
         ],
     }
     m = setup_mail_mock(requests_mock, conf)
+
     m.cc = ["@novem_demo", "@test"]
     assert m.cc == "@novem_demo\n@test"
+
     m.cc = "@novem_demo\n@test"
+    assert m.cc == "@novem_demo\n@test"
+
+    conf = {
+        "mail_id": "test_mail",
+        "reqs": [
+            [
+                "get",
+                "/recipients/cc",
+                "",
+            ],
+            [
+                "post",
+                "/recipients/cc",
+                None,
+            ],
+        ],
+    }
+    m = setup_mail_mock(requests_mock, conf)
+
+    m.cc = ""
+    assert m.cc == ""
+
+    m.cc = []
+    assert m.cc == ""
 
 
 def test_mail_recipients_bcc(requests_mock):
@@ -435,9 +483,31 @@ def test_mail_recipients_bcc(requests_mock):
         ],
     }
     m = setup_mail_mock(requests_mock, conf)
+
     m.bcc = ["@novem_demo", "@test"]
     assert m.bcc == "@novem_demo\n@test"
+
     m.bcc = "@novem_demo\n@test"
+    assert m.bcc == "@novem_demo\n@test"
+
+    conf = {
+        "mail_id": "test_mail",
+        "reqs": [
+            [
+                "get",
+                "/recipients/bcc",
+                "",
+            ],
+            ["post", "/recipients/bcc", None],
+        ],
+    }
+    m = setup_mail_mock(requests_mock, conf)
+
+    m.bcc = ""
+    assert m.bcc == ""
+
+    m.bcc = []
+    assert m.bcc == ""
 
 
 ###


### PR DESCRIPTION
This fixes a bug (#56) by sending an empty post request to the server when a user assigns an empty string or an empty list to any of the mail recipients.

This will **not** send a message in instances where the properties are assigned `None`.