### PR TITLE
vis: remove empty shares from updates

### DIFF
--- a/novem/vis/shared.py
+++ b/novem/vis/shared.py
@@ -46,10 +46,12 @@ class NovemShare(object):
         rms = set(es) - set(shares)
         adds = set(shares) - set(es)
 
-        for r in rms:
+        # Delete non-empty items
+        for r in filter(None, rms):
             self.api.api_delete(f"/shared/{r}")
 
-        for a in adds:
+        # Add non-empty items
+        for a in filter(None, adds):
             self.api.api_create(f"/shared/{a}")
 
     def __iadd__(self, share: str) -> List[str]:

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -77,6 +77,18 @@ def test_plot(requests_mock):
         text=partial(del_share, "+novem_demo~novem_test"),
     )
 
+    requests_mock.register_uri(
+        "delete",
+        f"{api_root}vis/plots/{plot_id}/shared/+novem_demo~novem_demo",
+        text=partial(del_share, "+novem_demo~novem_test"),
+    )
+
+    requests_mock.register_uri(
+        "delete",
+        f"{api_root}vis/plots/{plot_id}/shared/public",
+        text=partial(del_share, "public"),
+    )
+
     # create a novem api object
     n = Plot(plot_id, type=plot_type, config_path=config_file)  # config location
 
@@ -91,3 +103,5 @@ def test_plot(requests_mock):
 
     n.shared -= "+novem_demo~novem_test"
     # print(n.shared.get())
+
+    n.shared = ""


### PR DESCRIPTION
We incorrectly included an empty PUT to the share api as part of setting the shared to empty