### PR TITLE
cli: rename `-t` to `--type`

### DIFF
--- a/novem/cli/setup.py
+++ b/novem/cli/setup.py
@@ -312,7 +312,7 @@ def setup(raw_args: Any = None) -> Tuple[Any, Dict[str, str]]:
     )
 
     plot.add_argument(
-        "-t",
+        "--type",
         dest="type",
         action="store",
         required=False,

--- a/tests/test_cli_plots.py
+++ b/tests/test_cli_plots.py
@@ -567,7 +567,7 @@ def test_plot_types(cli, requests_mock, fs):
     )
 
     # set type
-    cli("-p", plot_name, "-t", in_type)
+    cli("-p", plot_name, "--type", in_type)
 
     assert in_type == out_plot_type
 


### PR DESCRIPTION
We'll be adding new tag support to the novem cli and feel like the `-t` shorthand is better used for tags. We will instead use `--type` for inline type setting.

Work towards: https://github.com/novem-code/novem-python/issues/106