### PR TITLE
workflows: add the Github App config to the release workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,9 +11,18 @@ jobs:
     permissions:
       contents: write
     steps:
+    - name: Generate GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
     - uses: actions/checkout@v4
       with:
+        ref: main
         fetch-depth: 0
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -48,12 +57,14 @@ jobs:
         poetry build
 
     - name: Commit version bump
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
-        # Show status for debugging
-        git status
+        # Explicitly set the remote URL with the app token
+        git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git
 
         # Add changed files
         git add pyproject.toml poetry.lock novem/version.py
@@ -61,7 +72,7 @@ jobs:
         # Only commit if there are changes
         if ! git diff --cached --quiet; then
           git commit -m "Release v$VERSION"
-          git push origin HEAD:main
+          git push origin main
         else
           echo "No changes to commit"
         fi


### PR DESCRIPTION
This is to solve the protected-branch commit-pushback issue.