### PR TITLE
release: strip dev stuff from the release-build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,19 @@ package = true
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.github",
+  "/tests",
+  "/scripts",
+  "/.pre-commit-config.yaml",
+  "/.mailmap",
+  "/flake.nix",
+  "/flake.lock",
+  "/uv.lock",
+  "/Makefile",
+]
+
 [tool.black]
 line-length = 120
 target-version = ['py38']


### PR DESCRIPTION
After the `poetry` -> `uv` switch, the release tgz and wheels went from
48kb / 67kb to 82kb / 238kb espectively.

After this, we're back at a more reasonable 64kb / 82kb. It's a tad bigger,
but we also included GraphQL, tag and profile support.
