### PR TITLE
pylib: add new table cell options

### DIFF
--- a/novem/vis/cell.py
+++ b/novem/vis/cell.py
@@ -135,3 +135,11 @@ class NovemCellConfig(object):
     @overflow.setter
     def overflow(self, style: Union[str, Selector]) -> None:
         return self.write("/config/table/cell/overflow", style)
+
+    @property
+    def priority(self) -> str:
+        return self._proxy("/config/table/cell/priority")
+
+    @priority.setter
+    def priority(self, style: Union[str, Selector]) -> None:
+        return self.write("/config/table/cell/priority", style)


### PR DESCRIPTION
We are expanding our table options with new `overflow`[1]  and `priority`[2] controls.

This PR exposes the endpoint on the `Plot.cell` utility object

[1] https://novem.io/docs/plot/config/table/#overflow
[2] https://novem.io/docs/plot/config/table/#priority
