### PR TITLE
jobs: add file support to `-R`

### DIFF
--- a/novem/cli/common.py
+++ b/novem/cli/common.py
@@ -359,7 +359,7 @@ def job(args: Dict[str, Any]) -> None:
     # -R (run): trigger job execution, optionally with file attachments
     if args.get("run_job") is not None:
         files = args["run_job"]
-        j.run(files=files if files else None)
+        j.run(files=files if files else None, output=args.get("output_dir"))
         return
 
     # --dump: dump entire API tree to file

--- a/novem/cli/common.py
+++ b/novem/cli/common.py
@@ -356,9 +356,10 @@ def job(args: Dict[str, Any]) -> None:
         is_cli=True,
     )
 
-    # -R (run): trigger job execution
-    if args.get("run_job"):
-        j.run()
+    # -R (run): trigger job execution, optionally with file attachments
+    if args.get("run_job") is not None:
+        files = args["run_job"]
+        j.run(files=files if files else None)
         return
 
     # --dump: dump entire API tree to file

--- a/novem/cli/setup.py
+++ b/novem/cli/setup.py
@@ -501,8 +501,10 @@ def setup(raw_args: Any = None) -> Tuple[Any, Dict[str, str]]:
     job.add_argument(
         "-R",
         dest="run_job",
-        action="store_true",
-        help="run the job",
+        nargs="*",
+        default=None,
+        metavar="@file",
+        help="run the job, optionally with one or more @file.ext to upload",
     )
 
     invite = parser.add_argument_group("invite")

--- a/novem/cli/setup.py
+++ b/novem/cli/setup.py
@@ -313,16 +313,6 @@ def setup(raw_args: Any = None) -> Tuple[Any, Dict[str, str]]:
     )
 
     vis.add_argument(
-        "-o",
-        metavar=("SOURCE"),
-        dest="for_other",
-        action="store",
-        required=False,
-        default=None,
-        help="specify entity to view vis for, @username, +org, @username~usergroup or +org~orggroup are supported",
-    )
-
-    vis.add_argument(
         "--comments",
         dest="comments",
         action="store_true",
@@ -505,6 +495,16 @@ def setup(raw_args: Any = None) -> Tuple[Any, Dict[str, str]]:
         default=None,
         metavar="@file",
         help="run the job, optionally with one or more @file.ext to upload",
+    )
+
+    job.add_argument(
+        "-o",
+        "--output",
+        dest="output_dir",
+        action="store",
+        default=None,
+        metavar="dir",
+        help="save job output to this directory (created if needed)",
     )
 
     invite = parser.add_argument_group("invite")

--- a/novem/job/__init__.py
+++ b/novem/job/__init__.py
@@ -390,7 +390,12 @@ class NovemJobAPI(NovemAPI):
                     f.write(chunk)
             print(dest)
         elif r.content:
-            print(r.text)
+            cd = r.headers.get("Content-Disposition", "")
+            fname = self._parse_filename(cd)
+            if fname:
+                print(f"Job produced output ({fname}). Use -o <dir> to save it.")
+            else:
+                print("Job completed.")
 
     def api_dump(self, outpath: str) -> None:
         """

--- a/novem/job/__init__.py
+++ b/novem/job/__init__.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -297,7 +298,36 @@ class NovemJobAPI(NovemAPI):
     def shortname(self) -> str:
         return self.api_read("/shortname").strip()
 
-    def run(self, files: Optional[List[str]] = None) -> None:
+    @staticmethod
+    def _parse_filename(content_disposition: str) -> Optional[str]:
+        """Extract filename from Content-Disposition header."""
+        # Try RFC 8187 filename* first (UTF-8 encoded)
+        m = re.search(r"filename\*\s*=\s*UTF-8''(.+?)(?:;|$)", content_disposition, re.IGNORECASE)
+        if m:
+            from urllib.parse import unquote
+
+            return unquote(m.group(1).strip())
+        # Fall back to plain filename
+        m = re.search(r'filename\s*=\s*"?([^";]+)"?', content_disposition)
+        if m:
+            return m.group(1).strip()
+        return None
+
+    @staticmethod
+    def _dedup_path(folder: str, name: str) -> str:
+        """Return a path in *folder* for *name*, adding (1), (2), … on conflict."""
+        candidate = os.path.join(folder, name)
+        if not os.path.exists(candidate):
+            return candidate
+        base, ext = os.path.splitext(name)
+        n = 1
+        while True:
+            candidate = os.path.join(folder, f"{base} ({n}){ext}")
+            if not os.path.exists(candidate):
+                return candidate
+            n += 1
+
+    def run(self, files: Optional[List[str]] = None, output: Optional[str] = None) -> None:
         """
         Trigger a job run by posting to /data.
 
@@ -305,6 +335,10 @@ class NovemJobAPI(NovemAPI):
         (e.g. ``@data.csv``).  The files are sent as ``multipart/form-data``
         with field names ``file_0``, ``file_1``, … and the original filename
         preserved.  Without files, an empty JSON body is sent.
+
+        If *output* is provided, the response body is saved to that directory
+        (created if necessary) using the filename from the server's
+        Content-Disposition header.
         """
         path = f"{self._api_root}jobs/{self.id}/data"
 
@@ -325,12 +359,13 @@ class NovemJobAPI(NovemAPI):
             if self._debug:
                 names = [os.path.basename(raw[1:]) for raw in files]
                 print(f"  files: {names}")
-            r = self._session.post(path, files=multipart)
+            r = self._session.post(path, files=multipart, stream=bool(output))
         else:
             r = self._session.post(
                 path,
                 headers={"Content-type": "application/json; charset=utf-8"},
                 data="{}",
+                stream=bool(output),
             )
 
         if not r.ok:
@@ -344,6 +379,18 @@ class NovemJobAPI(NovemAPI):
             except Exception:
                 print(f"Error: {r.text}")
             sys.exit(1)
+
+        if output:
+            os.makedirs(output, exist_ok=True)
+            cd = r.headers.get("Content-Disposition", "")
+            name = self._parse_filename(cd) or "output"
+            dest = self._dedup_path(output, name)
+            with open(dest, "wb") as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            print(dest)
+        elif r.content:
+            print(r.text)
 
     def api_dump(self, outpath: str) -> None:
         """

--- a/novem/job/__init__.py
+++ b/novem/job/__init__.py
@@ -297,20 +297,41 @@ class NovemJobAPI(NovemAPI):
     def shortname(self) -> str:
         return self.api_read("/shortname").strip()
 
-    def run(self) -> None:
+    def run(self, files: Optional[List[str]] = None) -> None:
         """
-        Trigger a job run by posting empty JSON to /data
+        Trigger a job run by posting to /data.
+
+        If *files* is provided, each entry must be prefixed with ``@``
+        (e.g. ``@data.csv``).  The files are sent as ``multipart/form-data``
+        with field names ``file_0``, ``file_1``, … and the original filename
+        preserved.  Without files, an empty JSON body is sent.
         """
         path = f"{self._api_root}jobs/{self.id}/data"
 
         if self._debug:
             print(f"POST: {path}")
 
-        r = self._session.post(
-            path,
-            headers={"Content-type": "application/json; charset=utf-8"},
-            data="{}",
-        )
+        if files:
+            multipart: List[Tuple[str, Any]] = []
+            for idx, raw in enumerate(files):
+                if not raw.startswith("@"):
+                    print(f"Error: file arguments must start with @, got: {raw}")
+                    sys.exit(1)
+                fpath = raw[1:]
+                if not os.path.isfile(fpath):
+                    print(f"Error: file not found: {fpath}")
+                    sys.exit(1)
+                multipart.append((f"file_{idx}", (os.path.basename(fpath), open(fpath, "rb"))))
+            if self._debug:
+                names = [os.path.basename(raw[1:]) for raw in files]
+                print(f"  files: {names}")
+            r = self._session.post(path, files=multipart)
+        else:
+            r = self._session.post(
+                path,
+                headers={"Content-type": "application/json; charset=utf-8"},
+                data="{}",
+            )
 
         if not r.ok:
             # Try to parse error message from JSON response

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -5,6 +5,8 @@ from contextlib import redirect_stdout
 from functools import partial
 from unittest.mock import patch
 
+import pytest
+
 from novem import Job
 from novem.exceptions import Novem403, Novem404
 from novem.utils import API_ROOT
@@ -584,3 +586,141 @@ def test_job_with_config_dict(requests_mock):
     assert j.config.type == new_type
     assert j.config.extract == new_extract
     assert j.config.render == new_render
+
+
+# ---------------------------------------------------------------------------
+# run() tests
+# ---------------------------------------------------------------------------
+
+
+def _make_job(requests_mock, job_id="test_job"):
+    """Helper: create a Job with mocked creation endpoint."""
+    base = os.path.dirname(os.path.abspath(__file__))
+    config_file = f"{base}/test.conf"
+    config = configparser.ConfigParser()
+    config.read(config_file)
+    api_root = config["general"]["api_root"]
+
+    requests_mock.register_uri("put", f"{api_root}jobs/{job_id}", text="")
+    return Job(job_id, config_path=config_file), api_root
+
+
+def test_job_run_no_files(requests_mock):
+    """run() without files sends empty JSON to /data."""
+    j, api_root = _make_job(requests_mock)
+
+    captured = {}
+
+    def handler(request, context):
+        captured["content_type"] = request.headers.get("Content-Type", "")
+        captured["body"] = request.text
+        return ""
+
+    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text=handler)
+
+    j.run()
+    assert "application/json" in captured["content_type"]
+    assert captured["body"] == "{}"
+
+
+def test_job_run_with_files(requests_mock, tmp_path):
+    """run() with @-prefixed files sends multipart/form-data preserving filenames."""
+    j, api_root = _make_job(requests_mock)
+
+    # Create temp files
+    f1 = tmp_path / "data.csv"
+    f1.write_text("a,b\n1,2\n")
+    f2 = tmp_path / "config.json"
+    f2.write_text('{"key": "val"}')
+
+    captured = {}
+
+    def handler(request, context):
+        captured["content_type"] = request.headers.get("Content-Type", "")
+        captured["body"] = request.body
+        return ""
+
+    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text=handler)
+
+    j.run(files=[f"@{f1}", f"@{f2}"])
+
+    assert "multipart/form-data" in captured["content_type"]
+    body = captured["body"]
+    # requests encodes multipart as bytes or PreparedRequest body
+    if isinstance(body, bytes):
+        body = body.decode("utf-8", errors="replace")
+    else:
+        body = str(body)
+    # Filenames should be preserved in Content-Disposition headers
+    assert "data.csv" in body
+    assert "config.json" in body
+    # Field names should follow file_0, file_1 convention
+    assert "file_0" in body
+    assert "file_1" in body
+
+
+def test_job_run_missing_at_prefix(requests_mock, tmp_path):
+    """run() rejects file args without @ prefix."""
+    j, api_root = _make_job(requests_mock)
+    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text="")
+
+    f1 = tmp_path / "data.csv"
+    f1.write_text("a,b\n1,2\n")
+
+    with pytest.raises(SystemExit):
+        j.run(files=[str(f1)])
+
+
+def test_job_run_file_not_found(requests_mock):
+    """run() exits if a file does not exist."""
+    j, api_root = _make_job(requests_mock)
+    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text="")
+
+    with pytest.raises(SystemExit):
+        j.run(files=["@nonexistent.csv"])
+
+
+def test_job_run_single_file(requests_mock, tmp_path):
+    """run() works with a single file."""
+    j, api_root = _make_job(requests_mock)
+
+    f1 = tmp_path / "report.xlsx"
+    f1.write_bytes(b"\x00\x01\x02")
+
+    captured = {}
+
+    def handler(request, context):
+        captured["content_type"] = request.headers.get("Content-Type", "")
+        captured["body"] = request.body
+        return ""
+
+    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text=handler)
+
+    j.run(files=[f"@{f1}"])
+
+    assert "multipart/form-data" in captured["content_type"]
+    body = captured["body"]
+    if isinstance(body, bytes):
+        body = body.decode("utf-8", errors="replace")
+    else:
+        body = str(body)
+    assert "file_0" in body
+    assert "report.xlsx" in body
+
+
+def test_job_run_api_error(requests_mock, tmp_path, capsys):
+    """run() prints error and exits on non-ok response."""
+    j, api_root = _make_job(requests_mock)
+
+    requests_mock.register_uri(
+        "post",
+        f"{api_root}jobs/{j.id}/data",
+        json={"error": "quota exceeded"},
+        status_code=402,
+    )
+
+    with pytest.raises(SystemExit):
+        j.run()
+
+    out = capsys.readouterr().out
+    assert "quota exceeded" in out

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -9,6 +9,7 @@ import pytest
 
 from novem import Job
 from novem.exceptions import Novem403, Novem404
+from novem.job import Job as _Job
 from novem.utils import API_ROOT
 
 
@@ -724,3 +725,142 @@ def test_job_run_api_error(requests_mock, tmp_path, capsys):
 
     out = capsys.readouterr().out
     assert "quota exceeded" in out
+
+
+# ---------------------------------------------------------------------------
+# run() output tests (-o)
+# ---------------------------------------------------------------------------
+
+
+def test_job_run_output_saves_file(requests_mock, tmp_path):
+    """run(output=...) saves response body using server filename."""
+    j, api_root = _make_job(requests_mock)
+    out_dir = str(tmp_path / "results")
+
+    requests_mock.register_uri(
+        "post",
+        f"{api_root}jobs/{j.id}/data",
+        content=b"col1,col2\n1,2\n",
+        headers={"Content-Disposition": 'attachment; filename="report.csv"'},
+    )
+
+    j.run(output=out_dir)
+
+    saved = os.path.join(out_dir, "report.csv")
+    assert os.path.isfile(saved)
+    assert open(saved, "rb").read() == b"col1,col2\n1,2\n"
+
+
+def test_job_run_output_rfc8187_filename(requests_mock, tmp_path):
+    """run(output=...) parses RFC 8187 filename* header."""
+    j, api_root = _make_job(requests_mock)
+    out_dir = str(tmp_path / "out")
+
+    requests_mock.register_uri(
+        "post",
+        f"{api_root}jobs/{j.id}/data",
+        content=b"data",
+        headers={"Content-Disposition": "attachment; filename*=UTF-8''r%C3%A9sult.pdf"},
+    )
+
+    j.run(output=out_dir)
+
+    saved = os.path.join(out_dir, "résult.pdf")
+    assert os.path.isfile(saved)
+
+
+def test_job_run_output_fallback_name(requests_mock, tmp_path):
+    """run(output=...) falls back to 'output' when no filename in header."""
+    j, api_root = _make_job(requests_mock)
+    out_dir = str(tmp_path / "out")
+
+    requests_mock.register_uri(
+        "post",
+        f"{api_root}jobs/{j.id}/data",
+        content=b"hello",
+        headers={},
+    )
+
+    j.run(output=out_dir)
+
+    saved = os.path.join(out_dir, "output")
+    assert os.path.isfile(saved)
+    assert open(saved, "rb").read() == b"hello"
+
+
+def test_job_run_output_dedup(requests_mock, tmp_path):
+    """run(output=...) adds (1), (2), … for duplicate filenames."""
+    j, api_root = _make_job(requests_mock)
+    out_dir = str(tmp_path / "out")
+    os.makedirs(out_dir)
+    # Pre-create a file to trigger dedup
+    open(os.path.join(out_dir, "report.csv"), "w").close()
+
+    requests_mock.register_uri(
+        "post",
+        f"{api_root}jobs/{j.id}/data",
+        content=b"new data",
+        headers={"Content-Disposition": 'attachment; filename="report.csv"'},
+    )
+
+    j.run(output=out_dir)
+
+    saved = os.path.join(out_dir, "report (1).csv")
+    assert os.path.isfile(saved)
+    assert open(saved, "rb").read() == b"new data"
+
+
+def test_job_run_output_creates_dir(requests_mock, tmp_path):
+    """run(output=...) creates the output directory if it doesn't exist."""
+    j, api_root = _make_job(requests_mock)
+    out_dir = str(tmp_path / "a" / "b" / "c")
+
+    requests_mock.register_uri(
+        "post",
+        f"{api_root}jobs/{j.id}/data",
+        content=b"ok",
+        headers={"Content-Disposition": 'attachment; filename="out.txt"'},
+    )
+
+    j.run(output=out_dir)
+
+    assert os.path.isfile(os.path.join(out_dir, "out.txt"))
+
+
+# ---------------------------------------------------------------------------
+# _parse_filename / _dedup_path unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_filename_plain():
+    assert _Job._parse_filename('attachment; filename="report.csv"') == "report.csv"
+
+
+def test_parse_filename_unquoted():
+    assert _Job._parse_filename("attachment; filename=report.csv") == "report.csv"
+
+
+def test_parse_filename_rfc8187():
+    assert _Job._parse_filename("attachment; filename*=UTF-8''r%C3%A9port.pdf") == "réport.pdf"
+
+
+def test_parse_filename_rfc8187_takes_precedence():
+    header = "attachment; filename=\"fallback.csv\"; filename*=UTF-8''preferred.csv"
+    assert _Job._parse_filename(header) == "preferred.csv"
+
+
+def test_parse_filename_missing():
+    assert _Job._parse_filename("attachment") is None
+    assert _Job._parse_filename("") is None
+
+
+def test_dedup_path_no_conflict(tmp_path):
+    assert _Job._dedup_path(str(tmp_path), "file.txt") == os.path.join(str(tmp_path), "file.txt")
+
+
+def test_dedup_path_with_conflicts(tmp_path):
+    open(tmp_path / "file.txt", "w").close()
+    assert _Job._dedup_path(str(tmp_path), "file.txt") == os.path.join(str(tmp_path), "file (1).txt")
+
+    open(tmp_path / "file (1).txt", "w").close()
+    assert _Job._dedup_path(str(tmp_path), "file.txt") == os.path.join(str(tmp_path), "file (2).txt")


### PR DESCRIPTION
This PR adds support for `@mentioning` files to the `-R` parameter, we also use `-o` for selecting output folder.

I think it would make sense in the future to rename `-i` to `--invites` and allow it to be made available for input short options matching `aux`