### PR TITLE
init: support credentials, oauth, and token auth types

### DIFF
--- a/novem/cli/__init__.py
+++ b/novem/cli/__init__.py
@@ -142,65 +142,33 @@ def refresh_config(args: Dict[str, Any]) -> None:
 
 def init_config(args: Dict[str, Any]) -> None:
     """
-    Initialize user and config
+    Initialize user and config.
 
-    the --init flag has been supplied, this means we are going to update the
-    configuration file. There are several different scenarios we have to adapt
-    to in this case:
-
-    * a simple --init with no options and missing config file
-      * request username and password from user
-      * authenticate against service
-      * create config file and store credentials if successful
-
-    * a simple --init with no options and existing config file
-      * check if config has a default user
-      * if default user exist in config, inform user that config
-      * already exist and terminate
-
-    * a simple --init with --profile <username> and missing config file
-      * request username and password from user
-        * with username prefilled as --profile
-      * authenticate against service
-      * create config file and store credentials if successful
-
-      --init
-
-      --profile
-      --token
-      --api-url
-      --force
-
-      user in config
-
-      config exist
-
-
-
-      if --token not supplied, request username and password
-      if --profile specified, prefill username
-
-      if token supplied request token info, if username password
-
+    --init [type]  where type is one of:
+      credentials  (default) prompt for username + password
+      oauth        browser-based OAuth flow
+      token        prompt for an existing novem token
     """
 
     if not args:
-        # make mypy happy, return if no argument supplied
         return
 
     _do_debug = False
     if "debug" in args and args["debug"]:
         _do_debug = True
 
-    token: Union[str, None] = None
-
-    if "token" in args:
-        token = args["token"]
-
     api_root: str = args["api-url"]
     profile: str = args["profile"]
     force: str = args["force"]
     config_path: str = args["config_path"]
+    init_type: str = args["init"]
+
+    if init_type not in ("credentials", "oauth", "token"):
+        print(
+            f'{cl.WARNING} ! {cl.ENDC}Unknown init type "{cl.OKCYAN}{init_type}{cl.ENDC}". '
+            f"Valid options: credentials, oauth, token"
+        )
+        sys.exit(1)
 
     # first check if we have a valid config
     if _do_debug:
@@ -214,52 +182,47 @@ def init_config(args: Dict[str, Any]) -> None:
         )
         sys.exit(1)
 
-    # resolve api_root early (needed for both token and password flows)
+    # resolve api_root early (needed for all flows)
     if not api_root:
         _, curconf = get_current_config(**args)
         api_root = curconf["api_root"]
 
+    # ensure api_root ends with /v1/ (user may pass bare domain like https://api.novem.io)
+    if not api_root.rstrip("/").endswith("/v1"):
+        api_root = api_root.rstrip("/") + "/v1/"
+    if not api_root.endswith("/"):
+        api_root = api_root + "/"
+
     ignore_ssl = args.get("ignore_ssl", False)
 
-    # handle --init --token flow: register an existing token
-    if token is True:  # flag given without value
-        token = getpass.getpass(" \u2022 novem token: ")
+    if init_type == "token":
+        _init_token(args, api_root, profile, config_path, ignore_ssl, _do_debug)
+    elif init_type == "oauth":
+        _init_oauth(args, api_root, profile, config_path, ignore_ssl, _do_debug)
+    else:
+        _init_credentials(args, api_root, profile, config_path, ignore_ssl, _do_debug)
 
-    if token:
-        if _do_debug:
-            print("INIT: validating supplied token")
 
-        try:
-            novem = NovemAPI(token=token, api_root=api_root, ignore_config=True, ignore_ssl=ignore_ssl, is_cli=True)
+def _init_credentials(
+    args: Dict[str, Any],
+    api_root: str,
+    profile: str,
+    config_path: str,
+    ignore_ssl: bool,
+    _do_debug: bool,
+) -> None:
+    """Authenticate with username and password, create a new API token."""
 
-            # validate token and get username via /whoami
-            username = novem.read("whoami")
-
-            # get token metadata
-            token_info = json.loads(novem.read("token"))
-            token_name = token_info["token_name"]
-
-        except (Novem401, Novem404, Exception) as e:
-            if _do_debug:
-                print(f"INIT: token validation failed: {e}")
-            print("Invalid or expired token")
-            sys.exit(1)
-
-        # default profile to username if not supplied
-        if not profile:
-            profile = username
-
-        do_update_config(profile, username, api_root, token_name, token, config_path)
-        return
-
-    # existing username/password flow
     if _do_debug:
-        print("INIT: construct token name")
+        print("INIT: starting credentials flow")
+
     valid_char_sm = string.ascii_lowercase + string.digits
     valid_char = valid_char_sm + "-_"
     hostname: str = socket.gethostname()
 
-    token_name = None
+    token_name: Union[str, None] = None
+    if "token-name" in args:
+        token_name = args["token-name"]
     if not token_name:
         token_hostname: str = "".join([x for x in hostname.lower() if x in valid_char])
         nounce: str = "".join(random.choice(valid_char_sm) for _ in range(8))
@@ -276,15 +239,11 @@ def init_config(args: Dict[str, Any]) -> None:
         token_name = new_token_name
 
     # get novem username
-    prefill = ""
-    if "profile" in args:
-        prefill = args["profile"]
-
-    if _do_debug:
-        print("INIT: request user input")
-
-    username = input_with_prefill(" \u2022 novem username: ", prefill)
-    # username = "abc"
+    username = ""
+    if profile:
+        username = input_with_prefill(" \u2022 novem username: ", profile)
+    else:
+        username = input(" \u2022 novem username: ")
 
     # get novem password
     password = getpass.getpass(" \u2022 novem password: ")
@@ -297,9 +256,6 @@ def init_config(args: Dict[str, Any]) -> None:
         "token_description": (f'cli token created for "{hostname}" ' f'on "{datetime.now():%Y-%m-%d:%H:%M:%S}"'),
     }
 
-    if _do_debug:
-        print("INIT: construct request")
-
     novem = NovemAPI(api_root=api_root, ignore_config=True, ignore_ssl=ignore_ssl, is_cli=True)
 
     try:
@@ -311,11 +267,87 @@ def init_config(args: Dict[str, Any]) -> None:
         print("Invalid username and/or password")
         sys.exit(1)
 
-    # default profile to username if not supplied
     if not profile:
         profile = username
 
-    # let's write our config
+    do_update_config(profile, username, api_root, token_name, token, config_path)
+
+
+def _init_token(
+    args: Dict[str, Any],
+    api_root: str,
+    profile: str,
+    config_path: str,
+    ignore_ssl: bool,
+    _do_debug: bool,
+) -> None:
+    """Register an existing novem token."""
+
+    if _do_debug:
+        print("INIT: starting token flow")
+
+    token: Union[str, None] = args.get("token")
+
+    if not token or token is True:
+        token = getpass.getpass(" \u2022 novem token: ")
+
+    if not token:
+        print("No token provided")
+        sys.exit(1)
+
+    try:
+        novem = NovemAPI(token=token, api_root=api_root, ignore_config=True, ignore_ssl=ignore_ssl, is_cli=True)
+
+        # validate token and get username via /whoami
+        username = novem.read("whoami")
+
+        # get token metadata
+        token_info = json.loads(novem.read("token"))
+        token_name = token_info["token_name"]
+
+    except (Novem401, Novem404, Exception) as e:
+        if _do_debug:
+            print(f"INIT: token validation failed: {e}")
+        print("Invalid or expired token")
+        sys.exit(1)
+
+    if not profile:
+        profile = username
+
+    do_update_config(profile, username, api_root, token_name, token, config_path)
+
+
+def _init_oauth(
+    args: Dict[str, Any],
+    api_root: str,
+    profile: str,
+    config_path: str,
+    ignore_ssl: bool,
+    _do_debug: bool,
+) -> None:
+    """Authenticate via browser-based OAuth flow."""
+
+    if _do_debug:
+        print("INIT: starting OAuth flow")
+
+    from .oauth import oauth_authenticate
+
+    token = oauth_authenticate(api_root, ignore_ssl=ignore_ssl)
+
+    # Use NovemAPI to fetch username and token metadata
+    novem = NovemAPI(token=token, api_root=api_root, ignore_config=True, ignore_ssl=ignore_ssl, is_cli=True)
+
+    username = novem.read("whoami")
+
+    try:
+        token_info = json.loads(novem.read("token"))
+        token_name = token_info["token_name"]
+    except Exception:
+        token_name = "oauth-cli"
+
+    if not profile:
+        profile = username
+
     do_update_config(profile, username, api_root, token_name, token, config_path)
 
 

--- a/novem/cli/oauth.py
+++ b/novem/cli/oauth.py
@@ -1,0 +1,261 @@
+"""
+OAuth 2.0 Authorization Code flow with PKCE for CLI authentication.
+
+Opens the user's browser to the Novem login page. A lightweight local
+HTTP server captures the authorization code callback, then exchanges
+it for a Novem API token.
+
+Falls back to out-of-band (OOB) manual code entry when the browser
+can't be opened (headless servers, SSH sessions, etc.).
+"""
+
+import hashlib
+import secrets
+import sys
+import threading
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Optional, Tuple
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import requests
+
+CLIENT_ID = "novem-cli"
+
+
+def _generate_pkce() -> Tuple[str, str]:
+    """Generate PKCE code_verifier and code_challenge (S256)."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    # base64url-encode without padding
+    challenge = (
+        digest.hex()  # not what we want — need proper base64url
+    )
+    # proper base64url encoding
+    import base64
+
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def _find_free_port() -> int:
+    """Find a free TCP port on localhost."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """HTTP handler that captures the OAuth callback and serves a success page."""
+
+    code: Optional[str] = None
+    state: Optional[str] = None
+    error: Optional[str] = None
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+
+        _CallbackHandler.code = params.get("code", [None])[0]
+        _CallbackHandler.state = params.get("state", [None])[0]
+        _CallbackHandler.error = params.get("error", [None])[0]
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+
+        if _CallbackHandler.code:
+            body = (
+                "<html><body style='font-family:system-ui;text-align:center;padding:60px'>"
+                "<h2>Authentication successful</h2>"
+                "<p>You can close this tab and return to the terminal.</p>"
+                "</body></html>"
+            )
+        else:
+            error_desc = params.get("error_description", ["Unknown error"])[0]
+            body = (
+                "<html><body style='font-family:system-ui;text-align:center;padding:60px'>"
+                f"<h2>Authentication failed</h2><p>{error_desc}</p>"
+                "</body></html>"
+            )
+        self.wfile.write(body.encode())
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Suppress default request logging."""
+        pass
+
+
+def oauth_authenticate(
+    api_root: str,
+    ignore_ssl: bool = False,
+) -> str:
+    """
+    Run the OAuth flow and return the API token.
+
+    1. Start local callback server
+    2. Open browser to authorize endpoint
+    3. Wait for callback with auth code
+    4. Exchange code for token
+
+    Falls back to OOB if browser can't be opened.
+
+    Returns:
+        token string
+
+    Raises:
+        SystemExit on failure
+    """
+    # Derive OAuth base URL from api_root (e.g. https://api.novem.io/v1/ → https://api.novem.io)
+    parsed = urlparse(api_root)
+    oauth_base = f"{parsed.scheme}://{parsed.hostname}"
+    if parsed.port and parsed.port not in (80, 443):
+        oauth_base = f"{oauth_base}:{parsed.port}"
+
+    code_verifier, code_challenge = _generate_pkce()
+    state = secrets.token_urlsafe(16)
+
+    # Try browser-based flow with local callback server
+    port = _find_free_port()
+    redirect_uri = f"http://localhost:{port}/callback"
+
+    code = _try_browser_flow(oauth_base, redirect_uri, state, code_challenge, port)
+
+    if code is None:
+        # Fallback to OOB
+        code = _try_oob_flow(oauth_base, state, code_challenge)
+
+    if not code:
+        print("Authentication cancelled.")
+        sys.exit(1)
+
+    # Exchange code for token
+    return _exchange_code(oauth_base, code, code_verifier, redirect_uri, ignore_ssl)
+
+
+def _try_browser_flow(
+    oauth_base: str,
+    redirect_uri: str,
+    state: str,
+    code_challenge: str,
+    port: int,
+) -> Optional[str]:
+    """Open browser and wait for callback. Returns auth code or None."""
+    params = urlencode(
+        {
+            "client_id": CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+    )
+    authorize_url = f"{oauth_base}/oauth/authorize?{params}"
+
+    # Reset handler state
+    _CallbackHandler.code = None
+    _CallbackHandler.state = None
+    _CallbackHandler.error = None
+
+    server = HTTPServer(("127.0.0.1", port), _CallbackHandler)
+    server.timeout = 120  # 2 minute timeout
+
+    # Try opening browser
+    print(f"\n  Opening browser to sign in...\n")
+    print(f"  If the browser doesn't open, visit:\n  {authorize_url}\n")
+
+    try:
+        opened = webbrowser.open(authorize_url)
+    except Exception:
+        opened = False
+
+    if not opened:
+        return None
+
+    # Wait for the callback (blocks until request or timeout)
+    # Run in a thread so we can handle keyboard interrupt
+    server_thread = threading.Thread(target=server.handle_request, daemon=True)
+    server_thread.start()
+
+    try:
+        server_thread.join(timeout=120)
+    except KeyboardInterrupt:
+        server.server_close()
+        return None
+
+    server.server_close()
+
+    if _CallbackHandler.error:
+        print(f"  Authentication error: {_CallbackHandler.error}")
+        return None
+
+    if _CallbackHandler.state != state:
+        print("  State mismatch — possible CSRF attack.")
+        return None
+
+    return _CallbackHandler.code
+
+
+def _try_oob_flow(
+    oauth_base: str,
+    state: str,
+    code_challenge: str,
+) -> Optional[str]:
+    """Fallback: print URL, user pastes auth code manually."""
+    params = urlencode(
+        {
+            "client_id": CLIENT_ID,
+            "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
+            "response_type": "code",
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+    )
+    authorize_url = f"{oauth_base}/oauth/authorize?{params}"
+
+    print(f"\n  Open this URL in your browser to sign in:\n")
+    print(f"  {authorize_url}\n")
+
+    try:
+        code = input("  Paste the authorization code here: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        return None
+
+    return code or None
+
+
+def _exchange_code(
+    oauth_base: str,
+    code: str,
+    code_verifier: str,
+    redirect_uri: str,
+    ignore_ssl: bool,
+) -> str:
+    """Exchange authorization code for a Novem API token."""
+    resp = requests.post(
+        f"{oauth_base}/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": CLIENT_ID,
+            "code_verifier": code_verifier,
+            "redirect_uri": redirect_uri,
+        },
+        verify=not ignore_ssl,
+    )
+
+    if resp.status_code != 200:
+        try:
+            error = resp.json().get("error_description", resp.text)
+        except Exception:
+            error = resp.text[:200]
+        print(f"  Token exchange failed: {error}")
+        sys.exit(1)
+
+    data = resp.json()
+    return data["access_token"]
+
+

--- a/novem/cli/oauth.py
+++ b/novem/cli/oauth.py
@@ -28,9 +28,7 @@ def _generate_pkce() -> Tuple[str, str]:
     verifier = secrets.token_urlsafe(64)
     digest = hashlib.sha256(verifier.encode("ascii")).digest()
     # base64url-encode without padding
-    challenge = (
-        digest.hex()  # not what we want — need proper base64url
-    )
+    challenge = digest.hex()  # not what we want — need proper base64url
     # proper base64url encoding
     import base64
 
@@ -163,7 +161,7 @@ def _try_browser_flow(
     server.timeout = 120  # 2 minute timeout
 
     # Try opening browser
-    print(f"\n  Opening browser to sign in...\n")
+    print("\n  Opening browser to sign in...\n")
     print(f"  If the browser doesn't open, visit:\n  {authorize_url}\n")
 
     try:
@@ -216,7 +214,7 @@ def _try_oob_flow(
     )
     authorize_url = f"{oauth_base}/oauth/authorize?{params}"
 
-    print(f"\n  Open this URL in your browser to sign in:\n")
+    print("\n  Open this URL in your browser to sign in:\n")
     print(f"  {authorize_url}\n")
 
     try:
@@ -257,5 +255,3 @@ def _exchange_code(
 
     data = resp.json()
     return data["access_token"]
-
-

--- a/novem/cli/setup.py
+++ b/novem/cli/setup.py
@@ -168,7 +168,7 @@ def setup(raw_args: Any = None) -> Tuple[Any, Dict[str, str]]:
         const=True,
         default=None,
         help="use this token instead, overrides profile lookup. "
-        "With --init, prompts for token to register an existing token",
+        "With --init token, supplies the token value directly",
     )
 
     parser.add_argument(
@@ -184,8 +184,13 @@ def setup(raw_args: Any = None) -> Tuple[Any, Dict[str, str]]:
     setup.add_argument(
         "--init",
         dest="init",
-        action="store_true",
-        help="authenticate with the novem service and create default configuration",
+        action="store",
+        nargs="?",
+        const="credentials",
+        default=None,
+        help="authenticate with the novem service and create default configuration. "
+        "Optional type: credentials (default, username+password), oauth (browser-based), "
+        "or token (paste an existing token)",
     )
 
     setup.add_argument(

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -443,7 +443,7 @@ token_info_resp = {
 
 
 def test_init_with_token_flag(requests_mock, fs, cli):
-    """Test --init --token with token provided via stdin prompt."""
+    """Test --init token with token provided via stdin prompt."""
     test_token = "test_token_value"
 
     # Mock /whoami to return username
@@ -459,7 +459,7 @@ def test_init_with_token_flag(requests_mock, fs, cli):
     assert not file_exists(cpath)
 
     # token is provided via stdin (getpass reads from stdin when /dev/tty is unavailable)
-    out, err = cli("--init", "--token", stdin=f"{test_token}\n")
+    out, err = cli("--init", "token", stdin=f"{test_token}\n")
 
     # verify that our config is there
     assert file_exists(cpath)
@@ -482,7 +482,7 @@ def test_init_with_token_flag(requests_mock, fs, cli):
 
 
 def test_init_with_token_and_profile(requests_mock, fs, cli):
-    """Test --init --token --profile to use a custom profile name."""
+    """Test --init token --profile to use a custom profile name."""
     test_token = "test_token_value"
 
     # Mock /whoami to return username
@@ -496,7 +496,7 @@ def test_init_with_token_and_profile(requests_mock, fs, cli):
 
     assert not file_exists(cpath)
 
-    out, err = cli("--init", "--token", "--profile", "myprofile", stdin=f"{test_token}\n")
+    out, err = cli("--init", "token", "--profile", "myprofile", stdin=f"{test_token}\n")
 
     assert file_exists(cpath)
 
@@ -526,7 +526,7 @@ def test_init_with_token_invalid(requests_mock, fs, cli):
     assert not file_exists(cpath)
 
     with pytest.raises(CliExit) as e:
-        cli("--init", "--token", stdin=f"{test_token}\n")
+        cli("--init", "token", stdin=f"{test_token}\n")
 
     out, err = e.value.args
     assert e.value.code == 1


### PR DESCRIPTION
## Summary
- `--init` now accepts an optional type parameter: `credentials` (default), `oauth`, or `token`
- Adds OAuth 2.0 Authorization Code flow with PKCE via new `novem/cli/oauth.py` — opens browser for login with OOB fallback for headless environments
- Normalizes `api_root` to include `/v1/` path
- Refactors `init_config` into separate `_init_credentials`, `_init_token`, and `_init_oauth` helpers