### PR TITLE
cli: improve jobs interface

### DIFF
--- a/novem/cli/common.py
+++ b/novem/cli/common.py
@@ -112,8 +112,14 @@ class VisBase:
             # We'll just use the raw api
             novem = NovemAPI(**args, is_cli=True)
 
+            usr_for_path = args.get("for_user") or None
+            if usr_for_path:
+                api_path = f"users/{usr_for_path}/vis/{self.fragment}/{name}"
+            else:
+                api_path = f"vis/{self.fragment}/{name}"
+
             try:
-                novem.delete(f"vis/{self.fragment}/{name}")
+                novem.delete(api_path)
                 return
             except Novem404:
                 print(f"{self.title} {name} did not exist")

--- a/novem/cli/common.py
+++ b/novem/cli/common.py
@@ -343,8 +343,10 @@ def job(args: Dict[str, Any]) -> None:
     # Delete job
     if args["delete"]:
         novem = NovemAPI(**args, is_cli=True)
+        usr_for_path = args.get("for_user") or None
+        api_path = f"users/{usr_for_path}/code/jobs/{name}" if usr_for_path else f"code/jobs/{name}"
         try:
-            novem.delete(f"jobs/{name}")
+            novem.delete(api_path)
             return
         except Novem404:
             print(f"Job {name} did not exist")

--- a/novem/cli/common.py
+++ b/novem/cli/common.py
@@ -376,8 +376,15 @@ def job(args: Dict[str, Any]) -> None:
     # -R (run): trigger job execution, optionally with file attachments
     if args.get("run_job") is not None:
         files = args["run_job"]
-        j.run(files=files if files else None, output=args.get("output_dir"))
+        j.run(
+            files=files if files else None,
+            input_dir=args.get("input_dir"),
+            output=args.get("output_dir"),
+        )
         return
+
+    if args.get("input_dir"):
+        print("Warning: -i/--input has no effect without -R (which triggers the run)", file=sys.stderr)
 
     # --dump: dump entire API tree to file
     if "dump" in args and args["dump"]:

--- a/novem/cli/setup.py
+++ b/novem/cli/setup.py
@@ -515,6 +515,16 @@ def setup(raw_args: Any = None) -> Tuple[Any, Dict[str, str]]:
     )
 
     job.add_argument(
+        "-i",
+        "--input",
+        dest="input_dir",
+        action="store",
+        default=None,
+        metavar="dir",
+        help="upload all files in this directory with -R (preserves subdirectories; -R @file wins on name conflict)",
+    )
+
+    job.add_argument(
         "-o",
         "--output",
         dest="output_dir",
@@ -527,7 +537,7 @@ def setup(raw_args: Any = None) -> Tuple[Any, Dict[str, str]]:
     invite = parser.add_argument_group("invite")
 
     invite.add_argument(
-        "-i",
+        "--invites",
         dest="invite",
         action="store",
         required=False,

--- a/novem/cli/vis.py
+++ b/novem/cli/vis.py
@@ -365,8 +365,14 @@ def list_vis_shares(vis_name: str, args: Dict[str, str], type: str) -> None:
 
     plist = []
 
+    for_user = args.get("for_user")
+    if for_user:
+        share_path = f"users/{for_user}/vis/{pth}s/{vis_name}/shared"
+    else:
+        share_path = f"vis/{pth}s/{vis_name}/shared"
+
     try:
-        plist = json.loads(novem.read(f"vis/{pth}s/{vis_name}/shared"))
+        plist = json.loads(novem.read(share_path))
     except Novem404:
         plist = []
 
@@ -389,8 +395,14 @@ def list_job_shares(job_name: str, args: Dict[str, str]) -> None:
 
     plist = []
 
+    for_user = args.get("for_user")
+    if for_user:
+        share_path = f"users/{for_user}/code/jobs/{job_name}/shared"
+    else:
+        share_path = f"code/jobs/{job_name}/shared"
+
     try:
-        plist = json.loads(novem.read(f"code/jobs/{job_name}/shared"))
+        plist = json.loads(novem.read(share_path))
     except Novem404:
         plist = []
 

--- a/novem/cli/vis.py
+++ b/novem/cli/vis.py
@@ -390,7 +390,7 @@ def list_job_shares(job_name: str, args: Dict[str, str]) -> None:
     plist = []
 
     try:
-        plist = json.loads(novem.read(f"jobs/{job_name}/shared"))
+        plist = json.loads(novem.read(f"code/jobs/{job_name}/shared"))
     except Novem404:
         plist = []
 
@@ -525,9 +525,9 @@ def list_job_tags(job_name: str, args: Dict[str, str]) -> None:
 
     for_user = args.get("for_user")
     if for_user:
-        tag_path = f"users/{for_user}/jobs/{job_name}/tags"
+        tag_path = f"users/{for_user}/code/jobs/{job_name}/tags"
     else:
-        tag_path = f"jobs/{job_name}/tags"
+        tag_path = f"code/jobs/{job_name}/tags"
 
     try:
         plist = json.loads(novem.read(tag_path))

--- a/novem/job/__init__.py
+++ b/novem/job/__init__.py
@@ -378,8 +378,12 @@ class NovemJobAPI(NovemAPI):
             if not os.path.isdir(input_dir):
                 print(f"Error: input directory not found: {input_dir}")
                 sys.exit(1)
-            for root, _dirs, walked in os.walk(input_dir):
+            for root, dirs, walked in os.walk(input_dir):
+                # skip hidden directories in-place so we don't descend into them
+                dirs[:] = [d for d in dirs if not d.startswith(".")]
                 for entry in walked:
+                    if entry.startswith("."):
+                        continue
                     fpath = os.path.join(root, entry)
                     rel = os.path.relpath(fpath, input_dir).replace(os.sep, "/")
                     upload[rel] = fpath
@@ -406,9 +410,11 @@ class NovemJobAPI(NovemAPI):
                 (f"file_{idx}", (mp_name, open(fpath, "rb"))) for idx, (mp_name, fpath) in enumerate(upload.items())
             ]
             if self._debug:
-                print(f"  files: {list(upload.keys())}")
+                print(f"  files in:  {len(upload)} ({list(upload.keys())})")
             r = self._session.post(path, files=multipart, stream=bool(output))
         else:
+            if self._debug:
+                print("  files in:  0")
             r = self._session.post(
                 path,
                 headers={"Content-type": "application/json; charset=utf-8"},
@@ -436,14 +442,21 @@ class NovemJobAPI(NovemAPI):
             with open(dest, "wb") as f:
                 for chunk in r.iter_content(chunk_size=8192):
                     f.write(chunk)
+            if self._debug:
+                print(f"  files out: 1 ({name})")
             print(dest)
         elif r.content:
             cd = r.headers.get("Content-Disposition", "")
             fname = self._parse_filename(cd)
+            if self._debug:
+                print(f"  files out: 1 ({fname or 'unnamed'}, not saved — use -o)")
             if fname:
                 print(f"Job produced output ({fname}). Use -o <dir> to save it.")
             else:
                 print("Job completed.")
+        else:
+            if self._debug:
+                print("  files out: 0")
 
     def api_dump(self, outpath: str) -> None:
         """

--- a/novem/job/__init__.py
+++ b/novem/job/__init__.py
@@ -121,6 +121,9 @@ class NovemJobAPI(NovemAPI):
                  for the type file in the config folder
         value: the value to write to the file
         """
+        if self.user:
+            print("You cannot modify another user's job")
+            return
 
         path = self._path(relpath)
 
@@ -153,6 +156,9 @@ class NovemJobAPI(NovemAPI):
                  for the type file in the config folder
         value: the value to write to the file
         """
+        if self.user:
+            print("You cannot modify another user's job")
+            return
 
         path = self._path(relpath)
 
@@ -190,6 +196,9 @@ class NovemJobAPI(NovemAPI):
                  for the type file in the config folder
         value: the value to write to the file
         """
+        if self.user:
+            print("You cannot modify another user's job")
+            return
 
         path = self._path(relpath)
 
@@ -508,6 +517,9 @@ class NovemJobAPI(NovemAPI):
         Load a dumped folder structure back into the API.
         Walks the folder and for each file: PUT to create, then POST content.
         """
+        if self.user:
+            print("You cannot modify another user's job")
+            return
 
         qpath = self._path()
 

--- a/novem/job/__init__.py
+++ b/novem/job/__init__.py
@@ -327,14 +327,27 @@ class NovemJobAPI(NovemAPI):
                 return candidate
             n += 1
 
-    def run(self, files: Optional[List[str]] = None, output: Optional[str] = None) -> None:
+    def run(
+        self,
+        files: Optional[List[str]] = None,
+        input_dir: Optional[str] = None,
+        output: Optional[str] = None,
+    ) -> None:
         """
         Trigger a job run by posting to /data.
 
         If *files* is provided, each entry must be prefixed with ``@``
         (e.g. ``@data.csv``).  The files are sent as ``multipart/form-data``
-        with field names ``file_0``, ``file_1``, … and the original filename
-        preserved.  Without files, an empty JSON body is sent.
+        with field names ``file_0``, ``file_1``, … and the basename preserved.
+
+        If *input_dir* is provided, every file under that directory is uploaded
+        too, using its path relative to *input_dir* as the multipart filename
+        so subdirectories are preserved on the server.
+
+        When the same multipart filename appears in both sources, the *files*
+        entry wins and a warning is emitted.
+
+        Without files or input_dir, an empty JSON body is sent.
 
         If *output* is provided, the response body is saved to that directory
         (created if necessary) using the filename from the server's
@@ -345,9 +358,20 @@ class NovemJobAPI(NovemAPI):
         if self._debug:
             print(f"POST: {path}")
 
+        upload: Dict[str, str] = {}
+
+        if input_dir:
+            if not os.path.isdir(input_dir):
+                print(f"Error: input directory not found: {input_dir}")
+                sys.exit(1)
+            for root, _dirs, walked in os.walk(input_dir):
+                for entry in walked:
+                    fpath = os.path.join(root, entry)
+                    rel = os.path.relpath(fpath, input_dir).replace(os.sep, "/")
+                    upload[rel] = fpath
+
         if files:
-            multipart: List[Tuple[str, Any]] = []
-            for idx, raw in enumerate(files):
+            for raw in files:
                 if not raw.startswith("@"):
                     print(f"Error: file arguments must start with @, got: {raw}")
                     sys.exit(1)
@@ -355,10 +379,20 @@ class NovemJobAPI(NovemAPI):
                 if not os.path.isfile(fpath):
                     print(f"Error: file not found: {fpath}")
                     sys.exit(1)
-                multipart.append((f"file_{idx}", (os.path.basename(fpath), open(fpath, "rb"))))
+                mp_name = os.path.basename(fpath)
+                if mp_name in upload and upload[mp_name] != fpath:
+                    print(
+                        f"Warning: -R @{fpath} overrides -i entry {upload[mp_name]} " f"(both upload as {mp_name})",
+                        file=sys.stderr,
+                    )
+                upload[mp_name] = fpath
+
+        if upload:
+            multipart: List[Tuple[str, Any]] = [
+                (f"file_{idx}", (mp_name, open(fpath, "rb"))) for idx, (mp_name, fpath) in enumerate(upload.items())
+            ]
             if self._debug:
-                names = [os.path.basename(raw[1:]) for raw in files]
-                print(f"  files: {names}")
+                print(f"  files: {list(upload.keys())}")
             r = self._session.post(path, files=multipart, stream=bool(output))
         else:
             r = self._session.post(

--- a/novem/job/__init__.py
+++ b/novem/job/__init__.py
@@ -41,9 +41,9 @@ class NovemJobAPI(NovemAPI):
 
         self.config = NovemJobConfig(self)
         if self.user:
-            base_path = f"users/{self.user}/jobs/{self.id}"
+            base_path = f"users/{self.user}/code/jobs/{self.id}"
         else:
-            base_path = f"jobs/{self.id}"
+            base_path = f"code/jobs/{self.id}"
         self.shared = NovemShare(self, base_path)
         self.tags = NovemTags(self, base_path)
 
@@ -89,12 +89,17 @@ class NovemJobAPI(NovemAPI):
         else:
             super().__setattr__(name, value)
 
+    def _path(self, relpath: str = "") -> str:
+        if self.user:
+            return f"{self._api_root}users/{self.user}/code/jobs/{self.id}{relpath}"
+        return f"{self._api_root}code/jobs/{self.id}{relpath}"
+
     def api_read(self, relpath: str) -> str:
         """
         Read the api value located at realtive path
         """
 
-        qpath = f"{self._api_root}jobs/{self.id}{relpath}"
+        qpath = self._path(relpath)
 
         if self._debug:
             print(f"GET: {qpath}")
@@ -117,7 +122,7 @@ class NovemJobAPI(NovemAPI):
         value: the value to write to the file
         """
 
-        path = f"{self._api_root}jobs/{self.id}{relpath}"
+        path = self._path(relpath)
 
         if self._debug:
             print(f"DELETE: {path}")
@@ -149,7 +154,7 @@ class NovemJobAPI(NovemAPI):
         value: the value to write to the file
         """
 
-        path = f"{self._api_root}jobs/{self.id}{relpath}"
+        path = self._path(relpath)
 
         if self._debug:
             print(f"PUT: {path}")
@@ -186,7 +191,7 @@ class NovemJobAPI(NovemAPI):
         value: the value to write to the file
         """
 
-        path = f"{self._api_root}jobs/{self.id}{relpath}"
+        path = self._path(relpath)
 
         if self._debug:
             print(f"POST: {path}")
@@ -353,7 +358,7 @@ class NovemJobAPI(NovemAPI):
         (created if necessary) using the filename from the server's
         Content-Disposition header.
         """
-        path = f"{self._api_root}jobs/{self.id}/data"
+        path = self._path("/data")
 
         if self._debug:
             print(f"POST: {path}")
@@ -437,7 +442,7 @@ class NovemJobAPI(NovemAPI):
         """
 
         # Base path without trailing slash
-        qpath = f"{self._api_root}jobs/{self.id}"
+        qpath = self._path()
 
         # create util function
         def rec_tree(path: str) -> None:
@@ -504,7 +509,7 @@ class NovemJobAPI(NovemAPI):
         Walks the folder and for each file: PUT to create, then POST content.
         """
 
-        qpath = f"{self._api_root}jobs/{self.id}"
+        qpath = self._path()
 
         def load_tree(local_path: str, api_path: str) -> None:
             full_local = os.path.join(inpath, local_path.lstrip("/")) if local_path else inpath
@@ -550,7 +555,7 @@ class NovemJobAPI(NovemAPI):
         clrs()
 
         # Base path without trailing slash - we'll add paths in rec_tree
-        qpath = f"{self._api_root}jobs/{self.id}"
+        qpath = self._path()
 
         # some display options
         c = "├"

--- a/novem/job/__init__.py
+++ b/novem/job/__init__.py
@@ -443,17 +443,12 @@ class NovemJobAPI(NovemAPI):
                 for chunk in r.iter_content(chunk_size=8192):
                     f.write(chunk)
             if self._debug:
-                print(f"  files out: 1 ({name})")
-            print(dest)
+                print(f"  files out: 1 ({name}) -> {dest}")
         elif r.content:
-            cd = r.headers.get("Content-Disposition", "")
-            fname = self._parse_filename(cd)
             if self._debug:
+                cd = r.headers.get("Content-Disposition", "")
+                fname = self._parse_filename(cd)
                 print(f"  files out: 1 ({fname or 'unnamed'}, not saved — use -o)")
-            if fname:
-                print(f"Job produced output ({fname}). Use -o <dir> to save it.")
-            else:
-                print("Job completed.")
         else:
             if self._debug:
                 print("  files out: 0")

--- a/novem/vis/__init__.py
+++ b/novem/vis/__init__.py
@@ -28,13 +28,13 @@ class NovemVisAPI(NovemAPI):
         if "debug" in kwargs and kwargs["debug"]:
             self._debug = True
 
+        if "user" in kwargs and kwargs["user"]:
+            self.user = kwargs["user"]
+
         if "create" not in kwargs or kwargs["create"]:
             # let's create our plot if -C specified, always
             # create when used as an api unless specifically told not to
             self.api_create("")
-
-        if "user" in kwargs and kwargs["user"]:
-            self.user = kwargs["user"]
 
         if "qpr" in kwargs and kwargs["qpr"]:
             self._qpr = kwargs["qpr"].replace(",", "&")

--- a/tests/test_cli_tags.py
+++ b/tests/test_cli_tags.py
@@ -244,14 +244,14 @@ def test_job_tag_list(cli, requests_mock, fs):
 
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_name}/tags",
+        f"{api_root}code/jobs/{job_name}/tags",
         text=json.dumps(tags),
         status_code=200,
     )
 
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_name}",
+        f"{api_root}code/jobs/{job_name}",
         status_code=201,
     )
 
@@ -279,22 +279,22 @@ def test_job_tag_add(cli, requests_mock, fs):
         context.status_code = 200
         return json.dumps([{"name": x} for x in tags])
 
-    requests_mock.register_uri("get", f"{api_root}jobs/{job_name}/tags", text=get_tags)
+    requests_mock.register_uri("get", f"{api_root}code/jobs/{job_name}/tags", text=get_tags)
 
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_name}/tags/fav",
+        f"{api_root}code/jobs/{job_name}/tags/fav",
         text=partial(add_tag, "fav"),
     )
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_name}/tags/wip",
+        f"{api_root}code/jobs/{job_name}/tags/wip",
         text=partial(add_tag, "wip"),
     )
 
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_name}",
+        f"{api_root}code/jobs/{job_name}",
         status_code=201,
     )
 
@@ -325,17 +325,17 @@ def test_job_tag_delete(cli, requests_mock, fs):
         context.status_code = 200
         return json.dumps([{"name": x} for x in tags])
 
-    requests_mock.register_uri("get", f"{api_root}jobs/{job_name}/tags", text=get_tags)
+    requests_mock.register_uri("get", f"{api_root}code/jobs/{job_name}/tags", text=get_tags)
 
     requests_mock.register_uri(
         "delete",
-        f"{api_root}jobs/{job_name}/tags/wip",
+        f"{api_root}code/jobs/{job_name}/tags/wip",
         text=partial(del_tag, "wip"),
     )
 
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_name}",
+        f"{api_root}code/jobs/{job_name}",
         status_code=201,
     )
 
@@ -409,18 +409,18 @@ def test_job_multiple_tags_delete(cli, requests_mock, fs):
         context.status_code = 200
         return json.dumps([{"name": x} for x in tags])
 
-    requests_mock.register_uri("get", f"{api_root}jobs/{job_name}/tags", text=get_tags)
+    requests_mock.register_uri("get", f"{api_root}code/jobs/{job_name}/tags", text=get_tags)
 
     for tag in ["fav", "wip"]:
         requests_mock.register_uri(
             "delete",
-            f"{api_root}jobs/{job_name}/tags/{tag}",
+            f"{api_root}code/jobs/{job_name}/tags/{tag}",
             text=partial(del_tag, tag),
         )
 
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_name}",
+        f"{api_root}code/jobs/{job_name}",
         status_code=201,
     )
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -801,6 +801,40 @@ def test_job_run_with_input_dir_preserves_subpaths(requests_mock, tmp_path):
     assert "top.csv" in body
 
 
+def test_job_run_input_dir_skips_dotfiles(requests_mock, tmp_path):
+    """run(input_dir=...) skips hidden files and hidden directories."""
+    j, api_root = _make_job(requests_mock)
+
+    indir = tmp_path / "in"
+    (indir / "sub").mkdir(parents=True)
+    (indir / ".git").mkdir()
+    (indir / "data.csv").write_text("x\n")
+    (indir / ".secret").write_text("nope")
+    (indir / "sub" / "ok.json").write_text("{}")
+    (indir / "sub" / ".hidden").write_text("nope")
+    (indir / ".git" / "HEAD").write_text("ref")
+
+    captured = {}
+
+    def handler(request, context):
+        captured["body"] = request.body
+        return ""
+
+    requests_mock.register_uri("post", f"{api_root}code/jobs/{j.id}/data", text=handler)
+
+    j.run(input_dir=str(indir))
+
+    body = captured["body"]
+    if isinstance(body, bytes):
+        body = body.decode("utf-8", errors="replace")
+    assert "data.csv" in body
+    assert "sub/ok.json" in body
+    # dotfiles and contents of hidden dirs must not appear
+    assert ".secret" not in body
+    assert ".hidden" not in body
+    assert "HEAD" not in body
+
+
 def test_job_run_input_dir_missing(requests_mock):
     """run(input_dir=...) exits if the directory does not exist."""
     j, api_root = _make_job(requests_mock)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -728,6 +728,83 @@ def test_job_run_api_error(requests_mock, tmp_path, capsys):
 
 
 # ---------------------------------------------------------------------------
+# run() input directory tests (-i)
+# ---------------------------------------------------------------------------
+
+
+def test_job_run_with_input_dir_preserves_subpaths(requests_mock, tmp_path):
+    """run(input_dir=...) walks the folder and preserves relative paths."""
+    j, api_root = _make_job(requests_mock)
+
+    indir = tmp_path / "in"
+    (indir / "sub").mkdir(parents=True)
+    (indir / "top.csv").write_text("x\n")
+    (indir / "sub" / "nested.json").write_text("{}")
+
+    captured = {}
+
+    def handler(request, context):
+        captured["content_type"] = request.headers.get("Content-Type", "")
+        captured["body"] = request.body
+        return ""
+
+    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text=handler)
+
+    j.run(input_dir=str(indir))
+
+    assert "multipart/form-data" in captured["content_type"]
+    body = captured["body"]
+    if isinstance(body, bytes):
+        body = body.decode("utf-8", errors="replace")
+    # Relative path with forward slash must reach the wire
+    assert "sub/nested.json" in body
+    assert "top.csv" in body
+
+
+def test_job_run_input_dir_missing(requests_mock):
+    """run(input_dir=...) exits if the directory does not exist."""
+    j, api_root = _make_job(requests_mock)
+    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text="")
+
+    with pytest.raises(SystemExit):
+        j.run(input_dir="/nope/does/not/exist")
+
+
+def test_job_run_files_override_input_dir(requests_mock, tmp_path, capsys):
+    """When -R basename collides with an -i entry, -R wins and a warning is emitted."""
+    j, api_root = _make_job(requests_mock)
+
+    indir = tmp_path / "in"
+    indir.mkdir()
+    (indir / "data.csv").write_text("from-input\n")
+
+    other = tmp_path / "other"
+    other.mkdir()
+    explicit = other / "data.csv"
+    explicit.write_text("from-R\n")
+
+    captured = {}
+
+    def handler(request, context):
+        captured["body"] = request.body
+        return ""
+
+    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text=handler)
+
+    j.run(files=[f"@{explicit}"], input_dir=str(indir))
+
+    body = captured["body"]
+    if isinstance(body, bytes):
+        body = body.decode("utf-8", errors="replace")
+    # Only the -R version's content should be present
+    assert "from-R" in body
+    assert "from-input" not in body
+
+    err = capsys.readouterr().err
+    assert "overrides" in err
+
+
+# ---------------------------------------------------------------------------
 # run() output tests (-o)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -35,7 +35,7 @@ def test_job_ref(requests_mock):
     # Job creation endpoint
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_id}",
+        f"{api_root}code/jobs/{job_id}",
         text=verify_create,
     )
     requests_mock.register_uri(
@@ -92,57 +92,57 @@ def test_job_properties(requests_mock):
     # Job creation endpoint
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_id}",
+        f"{api_root}code/jobs/{job_id}",
         text=verify_create,
     )
 
     # Property endpoints - GET
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/name",
+        f"{api_root}code/jobs/{job_id}/name",
         text=partial(verify_read, "name", job_name),
     )
 
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/description",
+        f"{api_root}code/jobs/{job_id}/description",
         text=partial(verify_read, "description", job_description),
     )
 
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/summary",
+        f"{api_root}code/jobs/{job_id}/summary",
         text=partial(verify_read, "summary", job_summary),
     )
 
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/config/type",
+        f"{api_root}code/jobs/{job_id}/config/type",
         text=partial(verify_read, "type", job_type),
     )
 
     # Property endpoints - POST (write)
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/name",
+        f"{api_root}code/jobs/{job_id}/name",
         text=partial(verify_write, "name", job_name),
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/description",
+        f"{api_root}code/jobs/{job_id}/description",
         text=partial(verify_write, "description", job_description),
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/summary",
+        f"{api_root}code/jobs/{job_id}/summary",
         text=partial(verify_write, "summary", job_summary),
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/config/type",
+        f"{api_root}code/jobs/{job_id}/config/type",
         text=partial(verify_write, "type", job_type),
     )
 
@@ -205,45 +205,45 @@ def test_job_config(requests_mock):
     # Job creation endpoint
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_id}",
+        f"{api_root}code/jobs/{job_id}",
         text=verify_create,
     )
 
     # Config endpoints - GET
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/config/type",
+        f"{api_root}code/jobs/{job_id}/config/type",
         text=partial(verify_read, "type", job_type),
     )
 
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/config/extract",
+        f"{api_root}code/jobs/{job_id}/config/extract",
         text=partial(verify_read, "extract", job_extract),
     )
 
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/config/render",
+        f"{api_root}code/jobs/{job_id}/config/render",
         text=partial(verify_read, "render", job_render),
     )
 
     # Config endpoints - POST (write)
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/config/type",
+        f"{api_root}code/jobs/{job_id}/config/type",
         text=partial(verify_write, "type", job_type),
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/config/extract",
+        f"{api_root}code/jobs/{job_id}/config/extract",
         text=partial(verify_write, "extract", job_extract),
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/config/render",
+        f"{api_root}code/jobs/{job_id}/config/render",
         text=partial(verify_write, "render", job_render),
     )
 
@@ -280,20 +280,20 @@ def test_job_url_shortname(requests_mock):
     # Job creation endpoint
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_id}",
+        f"{api_root}code/jobs/{job_id}",
         text="",
     )
 
     # URL and shortname endpoints
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/url",
+        f"{api_root}code/jobs/{job_id}/url",
         text=job_url,
     )
 
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/shortname",
+        f"{api_root}code/jobs/{job_id}/shortname",
         text=job_shortname,
     )
 
@@ -310,8 +310,8 @@ def test_job_log(requests_mock, fs):
     job_id = "test_job"
     log_content = "2023-05-01 12:00:00 - Job created\n2023-05-01 12:05:00 - Job started"
 
-    requests_mock.register_uri("put", f"{API_ROOT}jobs/{job_id}", text="", status_code=200)
-    requests_mock.register_uri("get", f"{API_ROOT}jobs/{job_id}/log", text=log_content, status_code=200)
+    requests_mock.register_uri("put", f"{API_ROOT}code/jobs/{job_id}", text="", status_code=200)
+    requests_mock.register_uri("get", f"{API_ROOT}code/jobs/{job_id}/log", text=log_content, status_code=200)
 
     j = Job(job_id)
 
@@ -338,32 +338,32 @@ def test_job_api_operations(requests_mock):
     # Job creation endpoint
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_id}",
+        f"{api_root}code/jobs/{job_id}",
         text="",
     )
 
     # API operations
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}{test_path}",
+        f"{api_root}code/jobs/{job_id}{test_path}",
         text=test_content,
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}{test_path}",
+        f"{api_root}code/jobs/{job_id}{test_path}",
         text="",
     )
 
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_id}{test_path}",
+        f"{api_root}code/jobs/{job_id}{test_path}",
         text="",
     )
 
     requests_mock.register_uri(
         "delete",
-        f"{api_root}jobs/{job_id}{test_path}",
+        f"{api_root}code/jobs/{job_id}{test_path}",
         text="",
     )
 
@@ -393,21 +393,21 @@ def test_job_w_function(requests_mock):
     # Job creation endpoint
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_id}",
+        f"{api_root}code/jobs/{job_id}",
         text="",
     )
 
     # Name endpoint for property
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/name",
+        f"{api_root}code/jobs/{job_id}/name",
         text="",
     )
 
     # Custom key endpoint for API
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}{custom_key}",
+        f"{api_root}code/jobs/{job_id}{custom_key}",
         text="",
     )
 
@@ -437,20 +437,20 @@ def test_job_error_handling(requests_mock):
     # Job creation endpoint
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_id}",
+        f"{api_root}code/jobs/{job_id}",
         text="",
     )
 
     # Error responses
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}{test_path}",
+        f"{api_root}code/jobs/{job_id}{test_path}",
         status_code=404,
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}{test_path}",
+        f"{api_root}code/jobs/{job_id}{test_path}",
         status_code=403,
     )
 
@@ -489,26 +489,26 @@ def test_job_with_config_dict(requests_mock):
     # Job creation endpoint
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_id}",
+        f"{api_root}code/jobs/{job_id}",
         text="",
     )
 
     # Config endpoints - POST
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/config/type",
+        f"{api_root}code/jobs/{job_id}/config/type",
         text="",
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/config/extract",
+        f"{api_root}code/jobs/{job_id}/config/extract",
         text="",
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/config/render",
+        f"{api_root}code/jobs/{job_id}/config/render",
         text="",
     )
 
@@ -518,19 +518,19 @@ def test_job_with_config_dict(requests_mock):
     # Register GET endpoints to check the config was set via the config dictionary
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/config/type",
+        f"{api_root}code/jobs/{job_id}/config/type",
         text=job_type,
     )
 
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/config/extract",
+        f"{api_root}code/jobs/{job_id}/config/extract",
         text=job_extract,
     )
 
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/config/render",
+        f"{api_root}code/jobs/{job_id}/config/render",
         text=job_render,
     )
 
@@ -546,19 +546,19 @@ def test_job_with_config_dict(requests_mock):
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/config/type",
+        f"{api_root}code/jobs/{job_id}/config/type",
         text="",
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/config/extract",
+        f"{api_root}code/jobs/{job_id}/config/extract",
         text="",
     )
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{job_id}/config/render",
+        f"{api_root}code/jobs/{job_id}/config/render",
         text="",
     )
 
@@ -567,19 +567,19 @@ def test_job_with_config_dict(requests_mock):
     # Update mocks for the new config values
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/config/type",
+        f"{api_root}code/jobs/{job_id}/config/type",
         text=new_type,
     )
 
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/config/extract",
+        f"{api_root}code/jobs/{job_id}/config/extract",
         text=new_extract,
     )
 
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/config/render",
+        f"{api_root}code/jobs/{job_id}/config/render",
         text=new_render,
     )
 
@@ -602,8 +602,48 @@ def _make_job(requests_mock, job_id="test_job"):
     config.read(config_file)
     api_root = config["general"]["api_root"]
 
-    requests_mock.register_uri("put", f"{api_root}jobs/{job_id}", text="")
+    requests_mock.register_uri("put", f"{api_root}code/jobs/{job_id}", text="")
     return Job(job_id, config_path=config_file), api_root
+
+
+def _make_shared_job(requests_mock, job_id="test_job", user="alice"):
+    """Helper: create a Job pointed at another user's namespace, no create call."""
+    base = os.path.dirname(os.path.abspath(__file__))
+    config_file = f"{base}/test.conf"
+    config = configparser.ConfigParser()
+    config.read(config_file)
+    api_root = config["general"]["api_root"]
+    return Job(job_id, user=user, create=False, config_path=config_file), api_root
+
+
+def test_job_user_prefix_api_read(requests_mock):
+    """api_read on a Job with user= targets users/<user>/jobs/<id>/..."""
+    j, api_root = _make_shared_job(requests_mock, user="alice")
+    requests_mock.register_uri("get", f"{api_root}users/alice/code/jobs/{j.id}/log", text="hello\n")
+    assert j.api_read("/log") == "hello\n"
+
+
+def test_job_user_prefix_log_property(requests_mock, capsys):
+    """The .log property on a shared job hits the user-prefixed path."""
+    j, api_root = _make_shared_job(requests_mock, user="alice")
+    requests_mock.register_uri("get", f"{api_root}users/alice/code/jobs/{j.id}/log", text="line\n")
+    j.log
+    assert "line" in capsys.readouterr().out
+
+
+def test_job_user_prefix_run(requests_mock, tmp_path):
+    """run() on a shared job posts to users/<user>/jobs/<id>/data."""
+    j, api_root = _make_shared_job(requests_mock, user="alice")
+
+    captured = {}
+
+    def handler(request, context):
+        captured["url"] = request.url
+        return ""
+
+    requests_mock.register_uri("post", f"{api_root}users/alice/code/jobs/{j.id}/data", text=handler)
+    j.run()
+    assert "users/alice/code/jobs/" in captured["url"]
 
 
 def test_job_run_no_files(requests_mock):
@@ -617,7 +657,7 @@ def test_job_run_no_files(requests_mock):
         captured["body"] = request.text
         return ""
 
-    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text=handler)
+    requests_mock.register_uri("post", f"{api_root}code/jobs/{j.id}/data", text=handler)
 
     j.run()
     assert "application/json" in captured["content_type"]
@@ -641,7 +681,7 @@ def test_job_run_with_files(requests_mock, tmp_path):
         captured["body"] = request.body
         return ""
 
-    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text=handler)
+    requests_mock.register_uri("post", f"{api_root}code/jobs/{j.id}/data", text=handler)
 
     j.run(files=[f"@{f1}", f"@{f2}"])
 
@@ -663,7 +703,7 @@ def test_job_run_with_files(requests_mock, tmp_path):
 def test_job_run_missing_at_prefix(requests_mock, tmp_path):
     """run() rejects file args without @ prefix."""
     j, api_root = _make_job(requests_mock)
-    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text="")
+    requests_mock.register_uri("post", f"{api_root}code/jobs/{j.id}/data", text="")
 
     f1 = tmp_path / "data.csv"
     f1.write_text("a,b\n1,2\n")
@@ -675,7 +715,7 @@ def test_job_run_missing_at_prefix(requests_mock, tmp_path):
 def test_job_run_file_not_found(requests_mock):
     """run() exits if a file does not exist."""
     j, api_root = _make_job(requests_mock)
-    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text="")
+    requests_mock.register_uri("post", f"{api_root}code/jobs/{j.id}/data", text="")
 
     with pytest.raises(SystemExit):
         j.run(files=["@nonexistent.csv"])
@@ -695,7 +735,7 @@ def test_job_run_single_file(requests_mock, tmp_path):
         captured["body"] = request.body
         return ""
 
-    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text=handler)
+    requests_mock.register_uri("post", f"{api_root}code/jobs/{j.id}/data", text=handler)
 
     j.run(files=[f"@{f1}"])
 
@@ -715,7 +755,7 @@ def test_job_run_api_error(requests_mock, tmp_path, capsys):
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{j.id}/data",
+        f"{api_root}code/jobs/{j.id}/data",
         json={"error": "quota exceeded"},
         status_code=402,
     )
@@ -748,7 +788,7 @@ def test_job_run_with_input_dir_preserves_subpaths(requests_mock, tmp_path):
         captured["body"] = request.body
         return ""
 
-    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text=handler)
+    requests_mock.register_uri("post", f"{api_root}code/jobs/{j.id}/data", text=handler)
 
     j.run(input_dir=str(indir))
 
@@ -764,7 +804,7 @@ def test_job_run_with_input_dir_preserves_subpaths(requests_mock, tmp_path):
 def test_job_run_input_dir_missing(requests_mock):
     """run(input_dir=...) exits if the directory does not exist."""
     j, api_root = _make_job(requests_mock)
-    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text="")
+    requests_mock.register_uri("post", f"{api_root}code/jobs/{j.id}/data", text="")
 
     with pytest.raises(SystemExit):
         j.run(input_dir="/nope/does/not/exist")
@@ -789,7 +829,7 @@ def test_job_run_files_override_input_dir(requests_mock, tmp_path, capsys):
         captured["body"] = request.body
         return ""
 
-    requests_mock.register_uri("post", f"{api_root}jobs/{j.id}/data", text=handler)
+    requests_mock.register_uri("post", f"{api_root}code/jobs/{j.id}/data", text=handler)
 
     j.run(files=[f"@{explicit}"], input_dir=str(indir))
 
@@ -816,7 +856,7 @@ def test_job_run_output_saves_file(requests_mock, tmp_path):
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{j.id}/data",
+        f"{api_root}code/jobs/{j.id}/data",
         content=b"col1,col2\n1,2\n",
         headers={"Content-Disposition": 'attachment; filename="report.csv"'},
     )
@@ -835,7 +875,7 @@ def test_job_run_output_rfc8187_filename(requests_mock, tmp_path):
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{j.id}/data",
+        f"{api_root}code/jobs/{j.id}/data",
         content=b"data",
         headers={"Content-Disposition": "attachment; filename*=UTF-8''r%C3%A9sult.pdf"},
     )
@@ -853,7 +893,7 @@ def test_job_run_output_fallback_name(requests_mock, tmp_path):
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{j.id}/data",
+        f"{api_root}code/jobs/{j.id}/data",
         content=b"hello",
         headers={},
     )
@@ -875,7 +915,7 @@ def test_job_run_output_dedup(requests_mock, tmp_path):
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{j.id}/data",
+        f"{api_root}code/jobs/{j.id}/data",
         content=b"new data",
         headers={"Content-Disposition": 'attachment; filename="report.csv"'},
     )
@@ -894,7 +934,7 @@ def test_job_run_output_creates_dir(requests_mock, tmp_path):
 
     requests_mock.register_uri(
         "post",
-        f"{api_root}jobs/{j.id}/data",
+        f"{api_root}code/jobs/{j.id}/data",
         content=b"ok",
         headers={"Content-Disposition": 'attachment; filename="out.txt"'},
     )

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -188,3 +188,31 @@ def test_plot_log(requests_mock, fs):
 
     output = f.getvalue().strip()
     assert output == "log_test_plot"
+
+
+def test_plot_with_user_does_not_create_on_caller_account(requests_mock):
+    """Constructing Plot(user=other) must not PUT to the caller's vis/plots/<id> path."""
+    base = os.path.dirname(os.path.abspath(__file__))
+    config_file = f"{base}/test.conf"
+    config = configparser.ConfigParser()
+    config.read(config_file)
+    api_root = config["general"]["api_root"]
+
+    own_put_calls = {"n": 0}
+
+    def own_put(request, context):
+        own_put_calls["n"] += 1
+        return ""
+
+    # Caller's own path — must not be hit
+    requests_mock.register_uri("put", f"{api_root}vis/plots/shared_plot", text=own_put)
+    # Read on the user-prefixed path is fine
+    requests_mock.register_uri("get", f"{api_root}users/alice/vis/plots/shared_plot/log", text="x")
+
+    p = Plot(id="shared_plot", user="alice", config_path=config_file)
+
+    f = io.StringIO()
+    with redirect_stdout(f):
+        p.log
+
+    assert own_put_calls["n"] == 0, "Plot(user=...) leaked a PUT onto the caller's account"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -576,14 +576,14 @@ def test_job_tags_integration(requests_mock):
     # Mock job creation endpoint
     requests_mock.register_uri(
         "put",
-        f"{api_root}jobs/{job_id}",
+        f"{api_root}code/jobs/{job_id}",
         text="",
     )
 
     # Tags endpoints
     requests_mock.register_uri(
         "get",
-        f"{api_root}jobs/{job_id}/tags",
+        f"{api_root}code/jobs/{job_id}/tags",
         text=get_tags,
     )
 
@@ -591,12 +591,12 @@ def test_job_tags_integration(requests_mock):
     for tag in ["fav", "like", "ignore", "wip", "archived", "+project_x"]:
         requests_mock.register_uri(
             "put",
-            f"{api_root}jobs/{job_id}/tags/{tag}",
+            f"{api_root}code/jobs/{job_id}/tags/{tag}",
             text=partial(put_tag, tag),
         )
         requests_mock.register_uri(
             "delete",
-            f"{api_root}jobs/{job_id}/tags/{tag}",
+            f"{api_root}code/jobs/{job_id}/tags/{tag}",
             text=partial(del_tag, tag),
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1552,7 +1552,7 @@ dev = [
 requires-dist = [
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'mcp'", specifier = ">=1.0.0" },
-    { name = "packaging", specifier = "==26.0" },
+    { name = "packaging", specifier = "==26.2" },
     { name = "pyreadline3", specifier = ">=3.5.4" },
     { name = "python-socketio", extras = ["asyncio-client"], marker = "extra == 'events'", specifier = ">=5.11.0" },
     { name = "requests", specifier = ">=2.32.4" },
@@ -1785,11 +1785,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Rename invites `-i` to `--invites` and free `-i` to work with jobs.

You can now specify input folders with `-i` as well as output folders with `-o` for job runs.

Also fix a bug where we could not access other users job items before.