### PR TITLE
cli: add support for --post --put etc utility functions

### DIFF
--- a/novem/cli/__init__.py
+++ b/novem/cli/__init__.py
@@ -570,6 +570,40 @@ novem --init --profile {args["profile"]}\
         print(f'{cl.OKGREEN} \u2713 {cl.ENDC}SSH key "{cl.OKCYAN}{key_id}{cl.ENDC}" {action} successfully')
         return
 
+    # handle raw HTTP commands (--get/--post/--put/--delete) — must run in isolation
+    if args:
+        from .http import active_http_flags, http_request, validate_isolation
+
+        if active_http_flags(args):
+            validate_isolation(args)
+
+            if args.get("http_get") is not None:
+                http_request(args, "GET", args["http_get"])
+                return
+            if args.get("http_post") is not None:
+                post_args = args["http_post"]
+                if len(post_args) == 1:
+                    http_request(args, "POST", post_args[0])
+                elif len(post_args) == 2:
+                    http_request(args, "POST", post_args[0], post_args[1])
+                else:
+                    print("Error: --post accepts 1 or 2 arguments (PATH [DATA])", file=sys.stderr)
+                    sys.exit(1)
+                return
+            if args.get("http_put") is not None:
+                put_args = args["http_put"]
+                if len(put_args) == 1:
+                    http_request(args, "PUT", put_args[0])
+                elif len(put_args) == 2:
+                    http_request(args, "PUT", put_args[0], put_args[1])
+                else:
+                    print("Error: --put accepts 1 or 2 arguments (PATH [DATA])", file=sys.stderr)
+                    sys.exit(1)
+                return
+            if args.get("http_delete") is not None:
+                http_request(args, "DELETE", args["http_delete"])
+                return
+
     # handle --gql to run a GraphQL query from stdin, file, or inline
     # Only run standalone if no other commands are specified
     if args and args.get("gql"):

--- a/novem/cli/http.py
+++ b/novem/cli/http.py
@@ -1,0 +1,131 @@
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+from ..api_ref import NovemAPI
+
+
+def active_http_flags(args: Dict[str, Any]) -> List[str]:
+    """Return the http flag names (e.g. ['--get']) that the user supplied."""
+    return [
+        name
+        for name, val in (
+            ("--get", args.get("http_get")),
+            ("--post", args.get("http_post")),
+            ("--put", args.get("http_put")),
+            ("--delete", args.get("http_delete")),
+        )
+        if val is not None
+    ]
+
+
+def _has_other_primary_command(args: Dict[str, Any]) -> bool:
+    """True when any non-http primary command/dispatch flag is set."""
+    if args.get("init"):
+        return True
+    if args.get("refresh"):
+        return True
+    if args.get("info"):
+        return True
+    if args.get("events") is not None:
+        return True
+    # add_ssh_key and gql default to False; True or a string means set
+    if args.get("add_ssh_key") is not False:
+        return True
+    if args.get("gql") is not False:
+        return True
+    # plot/mail/grid/doc/job/invite/for_user default to "" (unset)
+    for key in ("plot", "mail", "grid", "doc", "job", "invite", "for_user"):
+        if args.get(key) != "":
+            return True
+    # org/group use SUPPRESS — present in args dict means -O / -G was given
+    if "org" in args or "group" in args:
+        return True
+    return False
+
+
+def validate_isolation(args: Dict[str, Any]) -> None:
+    """Reject combining http flags with each other or with other commands."""
+    active = active_http_flags(args)
+    if not active:
+        return
+    if len(active) > 1:
+        print(
+            f"Error: {', '.join(active)} cannot be combined; use only one at a time",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if _has_other_primary_command(args):
+        print(
+            f"Error: {active[0]} must be used in isolation (no other -p/-g/-m/-j/-d/-u/-O/-G/--gql/etc.)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _resolve_data(value: str) -> bytes:
+    """`@filename` reads the file as bytes; otherwise treat as a literal string."""
+    if value.startswith("@"):
+        filename = os.path.expanduser(value[1:])
+        try:
+            with open(filename, "rb") as f:
+                return f.read()
+        except FileNotFoundError:
+            print(f'The supplied input file "{filename}" does not exist.', file=sys.stderr)
+            sys.exit(1)
+    return value.encode("utf-8")
+
+
+def _normalize_path(path: str) -> str:
+    """api_root ends with `/`, so a leading `/` on path would double it."""
+    return path.lstrip("/")
+
+
+def _read_stdin() -> Optional[bytes]:
+    """Return piped stdin bytes, or None when stdin is a TTY (no piped input)."""
+    if sys.stdin.isatty():
+        return None
+    return sys.stdin.read().encode("utf-8")
+
+
+def _emit(r: Any) -> None:
+    if r.text:
+        sys.stdout.write(r.text)
+        if not r.text.endswith("\n"):
+            sys.stdout.write("\n")
+    if not r.ok:
+        sys.exit(1)
+
+
+def http_request(
+    args: Dict[str, Any],
+    method: str,
+    path: str,
+    data: Optional[str] = None,
+) -> None:
+    if args.get("profile"):
+        args["config_profile"] = args["profile"]
+
+    body: Optional[bytes] = None
+    if data is not None:
+        body = _resolve_data(data)
+    elif method in ("POST", "PUT"):
+        body = _read_stdin()
+
+    if method == "POST" and body is None:
+        print(
+            "Error: --post requires DATA (inline string, @filename, or piped via stdin)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    novem = NovemAPI(**args, is_cli=True)
+    url = f"{novem._api_root}{_normalize_path(path)}"
+
+    request_kwargs: Dict[str, Any] = {}
+    if body is not None:
+        request_kwargs["headers"] = {"Content-type": "text/plain"}
+        request_kwargs["data"] = body
+
+    r = novem._session.request(method, url, **request_kwargs)
+    _emit(r)

--- a/novem/cli/setup.py
+++ b/novem/cli/setup.py
@@ -179,6 +179,56 @@ def setup(raw_args: Any = None) -> Tuple[Any, Dict[str, str]]:
         help="print info about the current user",
     )
 
+    http = parser.add_argument_group(
+        "raw http",
+        description="""\
+Issue a raw HTTP request against the novem api. PATH is everything after the
+api root (the part following /v1/), e.g. /vis/plots/my-plot/data. DATA can be
+an inline string or @filename to read from a file.""",
+    )
+
+    http.add_argument(
+        "--get",
+        dest="http_get",
+        action="store",
+        required=False,
+        default=None,
+        metavar="PATH",
+        help="GET the resource at PATH and print the response body",
+    )
+
+    http.add_argument(
+        "--post",
+        dest="http_post",
+        action="store",
+        required=False,
+        default=None,
+        nargs="+",
+        metavar=("PATH", "DATA"),
+        help="POST DATA to PATH. DATA is an inline string, @filename, or piped via stdin",
+    )
+
+    http.add_argument(
+        "--put",
+        dest="http_put",
+        action="store",
+        required=False,
+        default=None,
+        nargs="+",
+        metavar=("PATH", "DATA"),
+        help="PUT to PATH with optional DATA. DATA is an inline string, @filename, or piped via stdin",
+    )
+
+    http.add_argument(
+        "--delete",
+        dest="http_delete",
+        action="store",
+        required=False,
+        default=None,
+        metavar="PATH",
+        help="DELETE the resource at PATH",
+    )
+
     setup = parser.add_argument_group("setup")
 
     setup.add_argument(

--- a/novem/cli/setup.py
+++ b/novem/cli/setup.py
@@ -184,7 +184,7 @@ def setup(raw_args: Any = None) -> Tuple[Any, Dict[str, str]]:
         description="""\
 Issue a raw HTTP request against the novem api. PATH is everything after the
 api root (the part following /v1/), e.g. /vis/plots/my-plot/data. DATA can be
-an inline string or @filename to read from a file.""",
+an inline string, @filename to read from a file, or piped via stdin.""",
     )
 
     http.add_argument(

--- a/tests/test_cli_http.py
+++ b/tests/test_cli_http.py
@@ -1,0 +1,280 @@
+from novem.utils import API_ROOT
+
+from .conftest import CliExit
+from .utils import write_config
+
+auth_req = {
+    "username": "demouser",
+    "password": "demopass",
+    "token_name": "demotoken",
+    "token_description": "test token",
+}
+
+
+def _no_stdin(monkeypatch):
+    """Pretend stdin is a TTY so http handler doesn't try to read it."""
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+
+def test_http_get(cli, requests_mock, fs, monkeypatch):
+    """--get PATH performs a GET and prints the response body."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    requests_mock.register_uri(
+        "GET",
+        f"{API_ROOT}vis/plots/my-plot/data",
+        text="hello,world\n1,2\n",
+    )
+
+    out, err = cli("--get", "/vis/plots/my-plot/data")
+
+    assert out == "hello,world\n1,2\n"
+
+
+def test_http_get_strips_leading_slash(cli, requests_mock, fs, monkeypatch):
+    """Path without leading slash works the same."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    requests_mock.register_uri(
+        "GET",
+        f"{API_ROOT}whoami",
+        text="demouser",
+    )
+
+    out, err = cli("--get", "whoami")
+
+    assert "demouser" in out
+
+
+def test_http_post_inline(cli, requests_mock, fs, monkeypatch):
+    """--post PATH DATA sends DATA as the request body."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    captured = {}
+
+    def capture(request, context):
+        captured["body"] = request.text
+        captured["content_type"] = request.headers.get("Content-type")
+        context.status_code = 200
+        return ""
+
+    requests_mock.register_uri("POST", f"{API_ROOT}vis/plots/my-plot/data", text=capture)
+
+    cli("--post", "/vis/plots/my-plot/data", "hello world")
+
+    assert captured["body"] == "hello world"
+    assert captured["content_type"] == "text/plain"
+
+
+def test_http_post_from_file(cli, requests_mock, fs, monkeypatch):
+    """--post PATH @file reads DATA from file."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    with open("data.csv", "w") as f:
+        f.write("a,b,c\n1,2,3\n")
+
+    captured = {}
+
+    def capture(request, context):
+        captured["body"] = request.text
+        context.status_code = 200
+        return ""
+
+    requests_mock.register_uri("POST", f"{API_ROOT}vis/plots/my-plot/data", text=capture)
+
+    cli("--post", "/vis/plots/my-plot/data", "@data.csv")
+
+    assert captured["body"] == "a,b,c\n1,2,3\n"
+
+
+def test_http_post_missing_file(cli, requests_mock, fs, monkeypatch):
+    """@file pointing to a non-existent file errors out cleanly."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    requests_mock.register_uri("POST", f"{API_ROOT}vis/plots/my-plot/data", text="")
+
+    try:
+        cli("--post", "/vis/plots/my-plot/data", "@nope.csv")
+        assert False, "expected SystemExit"
+    except CliExit as e:
+        assert e.code == 1
+        assert "does not exist" in e.args[1]
+
+
+def test_http_post_from_stdin(cli, requests_mock, fs):
+    """--post PATH (no DATA) reads body from piped stdin."""
+    write_config(auth_req)
+
+    captured = {}
+
+    def capture(request, context):
+        captured["body"] = request.text
+        context.status_code = 200
+        return ""
+
+    requests_mock.register_uri("POST", f"{API_ROOT}vis/plots/my-plot/data", text=capture)
+
+    cli("--post", "/vis/plots/my-plot/data", stdin="from stdin\n")
+
+    assert captured["body"] == "from stdin\n"
+
+
+def test_http_post_no_data_tty_errors(cli, requests_mock, fs, monkeypatch):
+    """--post with no DATA and no piped stdin (TTY) is a usage error."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    try:
+        cli("--post", "/vis/plots/my-plot/data")
+        assert False, "expected SystemExit"
+    except CliExit as e:
+        assert e.code == 1
+        assert "--post requires DATA" in e.args[1]
+
+
+def test_http_put_no_data(cli, requests_mock, fs, monkeypatch):
+    """--put PATH with no DATA and no stdin sends an empty PUT."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    captured = {}
+
+    def capture(request, context):
+        captured["body"] = request.text or ""
+        captured["content_type"] = request.headers.get("Content-type")
+        context.status_code = 200
+        return ""
+
+    requests_mock.register_uri("PUT", f"{API_ROOT}vis/plots/my-plot", text=capture)
+
+    cli("--put", "/vis/plots/my-plot")
+
+    assert captured["body"] == ""
+    # No data => no Content-type set by us
+    assert captured["content_type"] != "text/plain"
+
+
+def test_http_put_with_data(cli, requests_mock, fs, monkeypatch):
+    """--put PATH DATA sends DATA as the request body."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    captured = {}
+
+    def capture(request, context):
+        captured["body"] = request.text
+        context.status_code = 200
+        return ""
+
+    requests_mock.register_uri("PUT", f"{API_ROOT}vis/plots/my-plot/name", text=capture)
+
+    cli("--put", "/vis/plots/my-plot/name", "My Plot")
+
+    assert captured["body"] == "My Plot"
+
+
+def test_http_put_from_stdin(cli, requests_mock, fs):
+    """--put PATH (no DATA) reads body from piped stdin."""
+    write_config(auth_req)
+
+    captured = {}
+
+    def capture(request, context):
+        captured["body"] = request.text
+        context.status_code = 200
+        return ""
+
+    requests_mock.register_uri("PUT", f"{API_ROOT}vis/plots/my-plot/config/type", text=capture)
+
+    cli("--put", "/vis/plots/my-plot/config/type", stdin="bar")
+
+    assert captured["body"] == "bar"
+
+
+def test_http_delete(cli, requests_mock, fs, monkeypatch):
+    """--delete PATH performs a DELETE."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    requests_mock.register_uri("DELETE", f"{API_ROOT}vis/plots/my-plot", status_code=204, text="")
+
+    out, err = cli("--delete", "/vis/plots/my-plot")
+
+    assert out == ""
+
+
+def test_http_rejects_combining_with_plot(cli, requests_mock, fs, monkeypatch):
+    """--get must not be combined with -p (or any other primary command)."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    try:
+        cli("--get", "/whoami", "-p", "my-plot")
+        assert False, "expected SystemExit"
+    except CliExit as e:
+        assert e.code == 1
+        assert "must be used in isolation" in e.args[1]
+
+
+def test_http_rejects_combining_with_gql(cli, requests_mock, fs, monkeypatch):
+    """--post must not be combined with --gql."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    try:
+        cli("--post", "/some/path", "data", "--gql", "{ me { username } }")
+        assert False, "expected SystemExit"
+    except CliExit as e:
+        assert e.code == 1
+        assert "must be used in isolation" in e.args[1]
+
+
+def test_http_rejects_combining_with_user(cli, requests_mock, fs, monkeypatch):
+    """--get must not be combined with -u (for_user)."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    try:
+        cli("--get", "/whoami", "-u", "alice")
+        assert False, "expected SystemExit"
+    except CliExit as e:
+        assert e.code == 1
+        assert "must be used in isolation" in e.args[1]
+
+
+def test_http_rejects_combining_two_http_flags(cli, requests_mock, fs, monkeypatch):
+    """--get and --delete cannot be used together."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    try:
+        cli("--get", "/path1", "--delete", "/path2")
+        assert False, "expected SystemExit"
+    except CliExit as e:
+        assert e.code == 1
+        assert "cannot be combined" in e.args[1]
+
+
+def test_http_get_error_response(cli, requests_mock, fs, monkeypatch):
+    """Non-2xx responses print the body and exit non-zero."""
+    write_config(auth_req)
+    _no_stdin(monkeypatch)
+
+    requests_mock.register_uri(
+        "GET",
+        f"{API_ROOT}vis/plots/missing",
+        status_code=404,
+        text="not found",
+    )
+
+    try:
+        cli("--get", "/vis/plots/missing")
+        assert False, "expected SystemExit"
+    except CliExit as e:
+        assert e.code == 1
+        assert "not found" in e.args[0]

--- a/tests/test_cli_http.py
+++ b/tests/test_cli_http.py
@@ -1,3 +1,5 @@
+import pytest
+
 from novem.utils import API_ROOT
 
 from .conftest import CliExit
@@ -208,52 +210,67 @@ def test_http_delete(cli, requests_mock, fs, monkeypatch):
     assert out == ""
 
 
-def test_http_rejects_combining_with_plot(cli, requests_mock, fs, monkeypatch):
-    """--get must not be combined with -p (or any other primary command)."""
+HTTP_FLAGS = [
+    ("--get", ("/whoami",)),
+    ("--post", ("/some/path", "data")),
+    ("--put", ("/some/path", "data")),
+    ("--delete", ("/some/path",)),
+]
+
+PRIMARY_COMMANDS = [
+    ("-p", ("my-plot",)),
+    ("-g", ("my-grid",)),
+    ("-m", ("my-mail",)),
+    ("-u", ("alice",)),
+    ("--gql", ("{ me { username } }",)),
+]
+
+
+@pytest.mark.parametrize("http_flag, http_args", HTTP_FLAGS)
+@pytest.mark.parametrize("primary_flag, primary_args", PRIMARY_COMMANDS)
+def test_http_rejects_combining_with_primary(
+    cli,
+    requests_mock,
+    fs,
+    monkeypatch,
+    http_flag,
+    http_args,
+    primary_flag,
+    primary_args,
+):
+    """HTTP flags must not be combined with primary commands."""
     write_config(auth_req)
     _no_stdin(monkeypatch)
 
     try:
-        cli("--get", "/whoami", "-p", "my-plot")
+        cli(http_flag, *http_args, primary_flag, *primary_args)
         assert False, "expected SystemExit"
     except CliExit as e:
         assert e.code == 1
         assert "must be used in isolation" in e.args[1]
 
 
-def test_http_rejects_combining_with_gql(cli, requests_mock, fs, monkeypatch):
-    """--post must not be combined with --gql."""
+@pytest.mark.parametrize("a_flag, a_args", HTTP_FLAGS)
+@pytest.mark.parametrize("b_flag, b_args", HTTP_FLAGS)
+def test_http_rejects_combining_two_http_flags(
+    cli,
+    requests_mock,
+    fs,
+    monkeypatch,
+    a_flag,
+    a_args,
+    b_flag,
+    b_args,
+):
+    """Two http flags cannot be used together."""
+    if a_flag == b_flag:
+        pytest.skip("same flag combined with itself is not a meaningful pair")
+
     write_config(auth_req)
     _no_stdin(monkeypatch)
 
     try:
-        cli("--post", "/some/path", "data", "--gql", "{ me { username } }")
-        assert False, "expected SystemExit"
-    except CliExit as e:
-        assert e.code == 1
-        assert "must be used in isolation" in e.args[1]
-
-
-def test_http_rejects_combining_with_user(cli, requests_mock, fs, monkeypatch):
-    """--get must not be combined with -u (for_user)."""
-    write_config(auth_req)
-    _no_stdin(monkeypatch)
-
-    try:
-        cli("--get", "/whoami", "-u", "alice")
-        assert False, "expected SystemExit"
-    except CliExit as e:
-        assert e.code == 1
-        assert "must be used in isolation" in e.args[1]
-
-
-def test_http_rejects_combining_two_http_flags(cli, requests_mock, fs, monkeypatch):
-    """--get and --delete cannot be used together."""
-    write_config(auth_req)
-    _no_stdin(monkeypatch)
-
-    try:
-        cli("--get", "/path1", "--delete", "/path2")
+        cli(a_flag, *a_args, b_flag, *b_args)
         assert False, "expected SystemExit"
     except CliExit as e:
         assert e.code == 1


### PR DESCRIPTION
When working with experimental novem features it's nice to have direct access to some of the functions such as `--post` `--put` etc 