### PR TITLE
cli: fix `novem --init` bug

### DIFF
--- a/novem/api_ref.py
+++ b/novem/api_ref.py
@@ -132,9 +132,14 @@ or set the NOVEM_TOKEN environment variable.\
         )
 
         if not r.ok:
-            resp = r.json()
+            try:
+                resp = r.json()
+            except ValueError:
+                resp = {}
+            message = resp.get("message") or r.text or f"HTTP {r.status_code}"
             if r.status_code == 401:
-                raise Novem401(resp["message"])
+                raise Novem401(message)
+            raise NovemException(message)
 
         return r.json()
 

--- a/novem/cli/__init__.py
+++ b/novem/cli/__init__.py
@@ -9,7 +9,7 @@ import urllib.request
 from datetime import datetime
 from typing import Any, Dict, Optional, Union
 
-from novem.exceptions import Novem401, Novem404
+from novem.exceptions import Novem401, Novem404, NovemException
 
 if os.name == "nt":
     from pyreadline3 import Readline  # type: ignore
@@ -36,6 +36,43 @@ def _cli_excepthook(exc_type: type, exc_value: BaseException, exc_traceback: Any
     """Custom exception handler for CLI mode - suppresses tracebacks unless in debug mode."""
     # Just print the exception message without traceback
     print(f"{exc_type.__name__}: {exc_value}", file=sys.stderr)
+
+
+# Server enforces ^[a-z][a-z0-9\-\._]*$ and length <= 128 on token names
+# (see mercurius.token_create in gaia/db/functions/token_create.sql).
+_TOKEN_NAME_VALID_CHARS = string.ascii_lowercase + string.digits + "-._"
+_TOKEN_NAME_LEADING_INVALID = string.digits + "-._"
+_TOKEN_NAME_MAX_LEN = 128
+_TOKEN_NAME_DEFAULT_LEN = 32
+
+
+def _sanitize_token_name(name: str) -> str:
+    """Coerce ``name`` to the server-side token name rules.
+
+    Lowercases, drops invalid characters, strips leading non-letter
+    characters, and clamps length. Returns "" if nothing usable remains.
+    """
+    cleaned = "".join(c for c in name.lower() if c in _TOKEN_NAME_VALID_CHARS)
+    cleaned = cleaned.lstrip(_TOKEN_NAME_LEADING_INVALID)
+    return cleaned[:_TOKEN_NAME_MAX_LEN]
+
+
+def _default_token_name(hostname: str) -> str:
+    """Generate ``np-<host>-<nonce>``, guaranteed to satisfy the server regex.
+
+    The hostname slice is bounded so the full name fits in
+    ``_TOKEN_NAME_DEFAULT_LEN`` characters and always starts with ``np-``.
+    """
+    nonce_chars = string.ascii_lowercase + string.digits
+    nonce = "".join(random.choice(nonce_chars) for _ in range(8))
+    host = "".join(c for c in hostname.lower() if c in _TOKEN_NAME_VALID_CHARS)
+    host = host.lstrip(_TOKEN_NAME_LEADING_INVALID)
+
+    max_host_len = _TOKEN_NAME_DEFAULT_LEN - len("np-") - len("-") - len(nonce)
+    host = host[:max_host_len].rstrip("-._")
+    if host:
+        return f"np-{host}-{nonce}"
+    return f"np-{nonce}"
 
 
 def input_with_prefill(prompt: str, text: str) -> Any:
@@ -87,25 +124,8 @@ def refresh_config(args: Dict[str, Any]) -> None:
     if "ignore_ssl_warn" in curconf:
         ignore_ssl = curconf["ignore_ssl_warn"]
 
-    valid_char_sm = string.ascii_lowercase + string.digits
-    valid_char = valid_char_sm + "-_"
     hostname: str = socket.gethostname()
-
-    token_name: Union[str, None] = None
-    if not token_name:
-        token_hostname: str = "".join([x for x in hostname.lower() if x in valid_char])
-        nounce: str = "".join(random.choice(valid_char_sm) for _ in range(8))
-        token_name = f"np-{token_hostname}-{nounce}".lower()[-32:]
-
-    new_token_name = "".join([x for x in token_name if x in valid_char])
-
-    if token_name != new_token_name:
-        print(
-            f"{cl.WARNING} ! {cl.ENDC}"
-            "The supplied token name contained invalid charracters,"
-            f' token changed to "{cl.OKCYAN}{new_token_name}{cl.ENDC}"'
-        )
-        token_name = new_token_name
+    token_name = _default_token_name(hostname)
 
     print(f"Refresh token for profile: {profile}")
 
@@ -129,12 +149,18 @@ def refresh_config(args: Dict[str, Any]) -> None:
 
     try:
         res = novem.create_token(req)
-        token = res["token"]
-        token_name = res["token_name"]
-
     except Novem401:
         print("Invalid username and/or password")
         sys.exit(1)
+    except NovemException as e:
+        print(f"Failed to create token: {e}")
+        sys.exit(1)
+
+    if "token" not in res or "token_name" not in res:
+        print(f"Unexpected response from token endpoint: {res}")
+        sys.exit(1)
+    token = res["token"]
+    token_name = res["token_name"]
 
     # update token
     do_update_config(profile, username, api_root, token_name, token, None)
@@ -216,27 +242,27 @@ def _init_credentials(
     if _do_debug:
         print("INIT: starting credentials flow")
 
-    valid_char_sm = string.ascii_lowercase + string.digits
-    valid_char = valid_char_sm + "-_"
     hostname: str = socket.gethostname()
-
-    token_name: Union[str, None] = None
-    if "token-name" in args:
-        token_name = args["token-name"]
-    if not token_name:
-        token_hostname: str = "".join([x for x in hostname.lower() if x in valid_char])
-        nounce: str = "".join(random.choice(valid_char_sm) for _ in range(8))
-        token_name = f"np-{token_hostname}-{nounce}".lower()[-32:]
-
-    new_token_name = "".join([x for x in token_name if x in valid_char])
-
-    if token_name != new_token_name:
-        print(
-            f"{cl.WARNING} ! {cl.ENDC}"
-            "The supplied token name contained invalid charracters,"
-            f' token changed to "{cl.OKCYAN}{new_token_name}{cl.ENDC}"'
-        )
-        token_name = new_token_name
+    requested_name: Union[str, None] = args.get("token-name")
+    if requested_name:
+        token_name = _sanitize_token_name(requested_name)
+        if not token_name:
+            print(
+                f"{cl.WARNING} ! {cl.ENDC}"
+                f'The supplied token name "{cl.OKCYAN}{requested_name}{cl.ENDC}" '
+                "has no valid characters; token names must start with a letter "
+                "and may only contain a-z, 0-9, -, ., _."
+            )
+            sys.exit(1)
+        if token_name != requested_name:
+            print(
+                f"{cl.WARNING} ! {cl.ENDC}"
+                "The supplied token name contained invalid characters or a leading "
+                "non-letter, "
+                f'token changed to "{cl.OKCYAN}{token_name}{cl.ENDC}"'
+            )
+    else:
+        token_name = _default_token_name(hostname)
 
     # get novem username
     username = ""
@@ -260,12 +286,18 @@ def _init_credentials(
 
     try:
         res = novem.create_token(req)
-        token = res["token"]
-        token_name = res["token_name"]
-
     except Novem401:
         print("Invalid username and/or password")
         sys.exit(1)
+    except NovemException as e:
+        print(f"Failed to create token: {e}")
+        sys.exit(1)
+
+    if "token" not in res or "token_name" not in res:
+        print(f"Unexpected response from token endpoint: {res}")
+        sys.exit(1)
+    token = res["token"]
+    token_name = res["token_name"]
 
     if not profile:
         profile = username

--- a/novem/cli/events.py
+++ b/novem/cli/events.py
@@ -68,7 +68,7 @@ def _format_event(data: Dict[str, Any]) -> str:
 
 async def _subscribe_events(args: Dict[str, Any], patterns: List[str]) -> None:
     try:
-        import socketio
+        import socketio  # type: ignore[import-untyped]
     except ImportError:
         print(
             'Error: The "events" extra is required for --events.\n' "Install it with: pip install novem[events]",

--- a/novem/events.py
+++ b/novem/events.py
@@ -79,7 +79,7 @@ class Events:
 
     def _check_deps(self) -> Any:
         try:
-            import socketio
+            import socketio  # type: ignore[import-untyped]
 
             return socketio
         except ImportError:

--- a/novem/table/selector.py
+++ b/novem/table/selector.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Any, List, Optional, Set, Union
 
 try:
@@ -32,7 +33,7 @@ def handle_position(position: Union[slice, Any, int], used_positions: Set[int]) 
     if isinstance(position, slice):
         # Convert slice to list of positions
         start = position.start if position.start is not None else 0
-        stop = position.stop if position.stop is not None else float("inf")
+        stop = position.stop if position.stop is not None else sys.maxsize
         step = position.step if position.step is not None else 1
         positions = list(range(start, stop, step))
         # Only take first position that hasn't been used

--- a/novem/utils.py
+++ b/novem/utils.py
@@ -144,8 +144,8 @@ def get_current_config(
     co = Config(
         {
             "token": kwargs.get("token", None),
-            "api_root": kwargs.get("api_root", None),
-            "ignore_ssl_warn": kwargs.get("ignore_ssl", False),
+            "api_root": kwargs.get("api_root") or "",
+            "ignore_ssl_warn": bool(kwargs.get("ignore_ssl", False)),
         }
     )
 
@@ -191,7 +191,7 @@ def get_current_config(
         co["username"] = uc["username"]
 
         if "ignore_ssl_warn" in uc:
-            co["ignore_ssl_warn"] = uc.getboolean("ignore_ssl_warn")
+            co["ignore_ssl_warn"] = uc.getboolean("ignore_ssl_warn", False)
 
     except KeyError:
         _apply_env_fallbacks(co)

--- a/tests/test_cli_init_token_name.py
+++ b/tests/test_cli_init_token_name.py
@@ -1,0 +1,144 @@
+import json
+import re
+
+import pytest
+
+from novem.api_ref import Novem401, NovemAPI, NovemException
+from novem.cli import _default_token_name, _sanitize_token_name
+from novem.utils import API_ROOT
+
+from .conftest import CliExit
+
+# Server-enforced rule from gaia/db/functions/token_create.sql
+SERVER_TOKEN_NAME_REGEX = re.compile(r"^[a-z][a-z0-9\-\._]*$")
+SERVER_TOKEN_NAME_MAX = 128
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("simple", "simple"),
+        ("Already-Mixed_Case.1", "already-mixed_case.1"),
+        ("123leading-digit", "leading-digit"),  # leading digits stripped
+        ("---dashes-only", "dashes-only"),  # leading dashes stripped
+        ("..._punct-leading", "punct-leading"),
+        ("123", ""),  # nothing valid remains
+        ("name with spaces!", "namewithspaces"),  # invalid chars dropped
+    ],
+)
+def test_sanitize_token_name(raw, expected):
+    assert _sanitize_token_name(raw) == expected
+    if expected:
+        assert SERVER_TOKEN_NAME_REGEX.match(expected)
+
+
+def test_sanitize_token_name_clamps_length():
+    name = "a" + "b" * 200
+    sanitized = _sanitize_token_name(name)
+    assert len(sanitized) == SERVER_TOKEN_NAME_MAX
+    assert SERVER_TOKEN_NAME_REGEX.match(sanitized)
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        "host",
+        "HOST.example.com",
+        "users-laptop-2024-something-very-long-name-here",
+        "12345-numeric-prefix",
+        "....",  # entirely invalid hostname
+        "",
+    ],
+)
+def test_default_token_name_satisfies_server_rules(hostname):
+    name = _default_token_name(hostname)
+    assert SERVER_TOKEN_NAME_REGEX.match(name), f"invalid token name {name!r}"
+    assert len(name) <= 32
+    assert name.startswith("np-")
+
+
+def test_default_token_name_includes_nonce():
+    # Two calls should differ (nonce randomness).
+    a = _default_token_name("host")
+    b = _default_token_name("host")
+    # Could collide once in 36**8, but practically never.
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: API-level errors must not crash with KeyError
+# ---------------------------------------------------------------------------
+
+
+auth_req = {
+    "username": "demouser",
+    "password": "demopass",
+}
+
+
+def test_init_handles_409_token_name_conflict(requests_mock, fs, cli):
+    """A non-401 failure (e.g. duplicate token name) used to crash with
+    KeyError: 'token'. It should now exit cleanly with the API message."""
+
+    requests_mock.register_uri(
+        "post",
+        f"{API_ROOT}token",
+        status_code=409,
+        text=json.dumps({"message": "Token name already exists"}),
+    )
+
+    with pytest.raises(CliExit) as exc:
+        cli("--init", stdin=f'{auth_req["username"]}\n{auth_req["password"]}')
+
+    out, _ = exc.value.args
+    assert exc.value.code == 1
+    assert "Token name already exists" in out
+    assert "KeyError" not in out
+
+
+def test_init_handles_500_with_no_message(requests_mock, fs, cli):
+    requests_mock.register_uri(
+        "post",
+        f"{API_ROOT}token",
+        status_code=500,
+        text="",
+    )
+
+    with pytest.raises(CliExit) as exc:
+        cli("--init", stdin=f'{auth_req["username"]}\n{auth_req["password"]}')
+
+    out, _ = exc.value.args
+    assert exc.value.code == 1
+    assert "Failed to create token" in out
+
+
+def test_create_token_raises_novem_exception_on_non_401(requests_mock, fs):
+    requests_mock.register_uri(
+        "post",
+        f"{API_ROOT}token",
+        status_code=409,
+        text=json.dumps({"message": "duplicate"}),
+    )
+
+    api = NovemAPI(api_root=API_ROOT, ignore_config=True, is_cli=True)
+    with pytest.raises(NovemException) as exc:
+        api.create_token({"username": "u", "password": "p", "token_name": "t"})
+    assert "duplicate" in str(exc.value)
+
+
+def test_create_token_still_raises_novem_401(requests_mock, fs):
+    requests_mock.register_uri(
+        "post",
+        f"{API_ROOT}token",
+        status_code=401,
+        text=json.dumps({"message": "bad creds"}),
+    )
+
+    api = NovemAPI(api_root=API_ROOT, ignore_config=True, is_cli=True)
+    with pytest.raises(Novem401):
+        api.create_token({"username": "u", "password": "p", "token_name": "t"})


### PR DESCRIPTION
Sometimes `novem --init` would fail because the generated token name was invalid.

This code fixes the token name so it matches what is expected by the server