### PR TITLE
vis/mail: fix include_picture typo and serialize bool params when false

### DIFF
--- a/novem/vis/grid.py
+++ b/novem/vis/grid.py
@@ -69,7 +69,7 @@ class Grid(NovemVisAPI):
         """
         Set's the layout of the grid
 
-        This paramter is expected to be one of the valid layout
+        This parameter is expected to be one of the valid layout
         strings or formats
         """
 

--- a/novem/vis/mail_sections.py
+++ b/novem/vis/mail_sections.py
@@ -184,7 +184,7 @@ class NovemEmailSectionApi(NovemEmailSection):
 
         plist = self._params + self._kwparams + self._cparams
 
-        # Add section controleld params first
+        # Add section controlled params first
         for p in plist:
             if not len(p):
                 continue
@@ -413,7 +413,7 @@ class AuthorSection(NovemEmailSectionApi):
         username: str,
         /,
         include_bio: bool = True,
-        include_pciture: bool = True,
+        include_picture: bool = True,
         override_bio: Optional[str] = None,
         **kwargs: str,
     ) -> None:

--- a/novem/vis/mail_sections.py
+++ b/novem/vis/mail_sections.py
@@ -55,9 +55,8 @@ class NovemEmailSectionApi(NovemEmailSection):
                     self._kwparams.append(ts)
 
             elif p.annotation is bool:
-                if v:
-                    ts = f"{k.replace('_', ' ')}: true"
-                    self._kwparams.append(ts)
+                ts = f"{k.replace('_', ' ')}: {'true' if v else 'false'}"
+                self._kwparams.append(ts)
 
             elif p.annotation is List[str]:
                 print("Treat as list of str")

--- a/tests/test_mail_sections.py
+++ b/tests/test_mail_sections.py
@@ -70,6 +70,8 @@ def test_mail_section_visualisation(requests_mock):
   ref: {plot_shortname}
   width: 100%
   align: center
+  include caption: false
+  include title: false
   include link: true
   override title: New title
   b: [l2 gray-300 purple, r1 red]

--- a/tests/test_mail_sections.py
+++ b/tests/test_mail_sections.py
@@ -110,7 +110,7 @@ def test_mail_section_author(requests_mock):
     rest = """{{ author
   username: demo
   include bio: true
-  include pciture: true
+  include picture: true
 }}
 
 {{ /author }}"""

--- a/uv.lock
+++ b/uv.lock
@@ -1283,7 +1283,7 @@ wheels = [
 
 [[package]]
 name = "novem"
-version = "0.5.14"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "colorama" },


### PR DESCRIPTION
- Fix typos: `paramter`, `controleld`, and the `include_pciture` → `include_picture` section param.
- Serialize boolean section params when `false` so default-ON toggles (include_caption/title/link/bio/picture) can actually be turned off — the renderer only hides an element when its instruction key is present and set to false.