### PR TITLE
sdk: raise NovemException on API errors instead of a print placeholder

### DIFF
--- a/novem/api_ref.py
+++ b/novem/api_ref.py
@@ -67,6 +67,39 @@ class NovemAuthError(NovemException):
     pass
 
 
+def raise_on_response(r: requests.Response) -> None:
+    """Raise the appropriate ``NovemException`` for a non-ok API response.
+
+    Surfaces the server's ``message`` and any ``rejected`` lines (e.g. the
+    recipient-write reject contract) so callers get a real exception to catch
+    instead of a silent no-op. No-op on a successful response.
+    """
+    if r.ok or r.status_code == 409:
+        return
+
+    try:
+        resp = r.json()
+    except ValueError:
+        resp = {}
+
+    message = resp.get("message") or r.text or f"HTTP {r.status_code}"
+
+    rejected = resp.get("rejected")
+    if rejected:
+        lines = "; ".join(f'{item.get("line")}: {item.get("reason")}' for item in rejected if isinstance(item, dict))
+        if lines:
+            message = f"{message} [{lines}]"
+
+    code = r.status_code
+    if code == 401:
+        raise Novem401(message)
+    if code == 403:
+        raise Novem403(message)
+    if code == 404:
+        raise Novem404(message)
+    raise NovemException(message)
+
+
 class NovemAPI(object):
     """
     Novem API class

--- a/novem/exceptions/__init__.py
+++ b/novem/exceptions/__init__.py
@@ -1,3 +1,19 @@
-from ..api_ref import Novem401, Novem403, Novem404, NovemAuthError, NovemException
+from ..api_ref import (
+    Novem401,
+    Novem403,
+    Novem404,
+    Novem409,
+    NovemAuthError,
+    NovemException,
+    raise_on_response,
+)
 
-__all__ = ["NovemException", "Novem404", "Novem403", "Novem401", "NovemAuthError"]
+__all__ = [
+    "NovemException",
+    "Novem404",
+    "Novem403",
+    "Novem401",
+    "Novem409",
+    "NovemAuthError",
+    "raise_on_response",
+]

--- a/novem/exceptions/__init__.py
+++ b/novem/exceptions/__init__.py
@@ -1,12 +1,4 @@
-from ..api_ref import (
-    Novem401,
-    Novem403,
-    Novem404,
-    Novem409,
-    NovemAuthError,
-    NovemException,
-    raise_on_response,
-)
+from ..api_ref import Novem401, Novem403, Novem404, Novem409, NovemAuthError, NovemException, raise_on_response
 
 __all__ = [
     "NovemException",

--- a/novem/group/__init__.py
+++ b/novem/group/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 
-from novem.exceptions import Novem403, Novem404
+from novem.exceptions import Novem403, Novem404, raise_on_response
 
 from ..api_ref import NovemAPI
 from .profile import NovemGroupProfile
@@ -147,17 +147,8 @@ class NovemGroupAPI(NovemAPI):
             # as creating objects that already exist is not a problem
             return
 
-        # TODO: verify result and raise exception if not ok
         if not r.ok:
-            print(r)
-            print(f"PUT: {path}")
-            print("body")
-            print("---")
-            print(r.text)
-            print("headers")
-            print("---")
-            print(r.headers)
-            print("should raise a general error")
+            raise_on_response(r)
 
     def api_write(self, relpath: str, value: str) -> None:
         """
@@ -180,22 +171,8 @@ class NovemGroupAPI(NovemAPI):
         if r.status_code == 404:
             raise Novem404(path)
 
-        if r.status_code == 403:
-            raise Novem403
-
-        # TODO: verify result and raise exception if not ok
         if not r.ok:
-            print(r)
-            print(f"POST: {path} {value}")
-            print("body")
-            print("---")
-            print(r.text)
-            print(r.status_code)
-            print("headers")
-            print("---")
-            for k, v in r.headers.items():
-                print(f"   {k}: {v}")
-            print("should raise a general error")
+            raise_on_response(r)
 
     @property
     def permissions(self) -> str:

--- a/novem/job/__init__.py
+++ b/novem/job/__init__.py
@@ -3,7 +3,7 @@ import re
 import sys
 from typing import Any, Dict, List, Optional, Tuple
 
-from novem.exceptions import Novem403, Novem404
+from novem.exceptions import Novem403, Novem404, raise_on_response
 
 from ..api_ref import NovemAPI
 from ..shared import NovemShare
@@ -182,17 +182,8 @@ class NovemJobAPI(NovemTreeSync, NovemAPI):
             # as creating objects that already exist is not a problem
             return
 
-        # TODO: verify result and raise exception if not ok
         if not r.ok:
-            print(r)
-            print(f"PUT: {path}")
-            print("body")
-            print("---")
-            print(r.text)
-            print("headers")
-            print("---")
-            print(r.headers)
-            print("should raise a general error")
+            raise_on_response(r)
 
     def api_write(self, relpath: str, value: str) -> None:
         """
@@ -218,22 +209,8 @@ class NovemJobAPI(NovemTreeSync, NovemAPI):
         if r.status_code == 404:
             raise Novem404(path)
 
-        if r.status_code == 403:
-            raise Novem403
-
-        # TODO: verify result and raise exception if not ok
         if not r.ok:
-            print(r)
-            print(f"POST: {path} {value}")
-            print("body")
-            print("---")
-            print(r.text)
-            print(r.status_code)
-            print("headers")
-            print("---")
-            for k, v in r.headers.items():
-                print(f"   {k}: {v}")
-            print("should raise a general error")
+            raise_on_response(r)
 
     # chainable utility function for setting values
     def w(self, key: str, value: str) -> Any:

--- a/novem/repo/__init__.py
+++ b/novem/repo/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 
-from novem.exceptions import Novem403, Novem404
+from novem.exceptions import Novem403, Novem404, raise_on_response
 
 from ..api_ref import NovemAPI
 from ..shared import NovemShare
@@ -144,17 +144,8 @@ class NovemRepoAPI(NovemAPI):
             # as creating objects that already exist is not a problem
             return
 
-        # TODO: verify result and raise exception if not ok
         if not r.ok:
-            print(r)
-            print(f"PUT: {path}")
-            print("body")
-            print("---")
-            print(r.text)
-            print("headers")
-            print("---")
-            print(r.headers)
-            print("should raise a general error")
+            raise_on_response(r)
 
     def api_write(self, relpath: str, value: str) -> None:
         """
@@ -177,22 +168,8 @@ class NovemRepoAPI(NovemAPI):
         if r.status_code == 404:
             raise Novem404(path)
 
-        if r.status_code == 403:
-            raise Novem403
-
-        # TODO: verify result and raise exception if not ok
         if not r.ok:
-            print(r)
-            print(f"POST: {path} {value}")
-            print("body")
-            print("---")
-            print(r.text)
-            print(r.status_code)
-            print("headers")
-            print("---")
-            for k, v in r.headers.items():
-                print(f"   {k}: {v}")
-            print("should raise a general error")
+            raise_on_response(r)
 
     # chainable utility function for setting values
     def w(self, key: str, value: str) -> Any:

--- a/novem/vis/__init__.py
+++ b/novem/vis/__init__.py
@@ -2,7 +2,7 @@ import sys
 import warnings
 from typing import Any, Dict, List, Optional, Tuple
 
-from novem.exceptions import Novem403, Novem404
+from novem.exceptions import Novem403, Novem404, raise_on_response
 
 from ..api_ref import NovemAPI
 from ..shared import NovemShare
@@ -383,17 +383,8 @@ class NovemVisAPI(NovemTreeSync, NovemAPI):
             # as creating objects that already exist is not a problem
             return
 
-        # TODO: verify result and raise exception if not ok
         if not r.ok:
-            print(r)
-            print(f"PUT: {path}")
-            print("body")
-            print("---")
-            print(r.text)
-            print("headers")
-            print("---")
-            print(r.headers)
-            print("should raise a general error")
+            raise_on_response(r)
 
     def api_write(self, relpath: str, value: str) -> None:
         """
@@ -419,22 +410,8 @@ class NovemVisAPI(NovemTreeSync, NovemAPI):
         if r.status_code == 404:
             raise Novem404(path)
 
-        if r.status_code == 403:
-            raise Novem403
-
-        # TODO: verify result and raise exception if not ok
         if not r.ok:
-            print(r)
-            print(f"POST: {path} {value}")
-            print("body")
-            print("---")
-            print(r.text)
-            print(r.status_code)
-            print("headers")
-            print("---")
-            for k, v in r.headers.items():
-                print(f"   {k}: {v}")
-            print("should raise a general error")
+            raise_on_response(r)
 
     @property
     def log(self) -> None:


### PR DESCRIPTION
**Draft — implements the fail-hard option from #235 for discussion.**

## What
Adds `raise_on_response(r)` (`api_ref`) — parses the server `message` and any `rejected` lines and raises the matching `NovemException` subclass (401/403/404, generic `NovemException` otherwise) — and replaces the `print("should raise a general error")` placeholder in all eight write sites (`vis`/`group`/`job`/`repo`, the `create_*` PUT + `api_write` POST).

409 is treated as a platform-wide no-op (idempotency): `raise_on_response` returns early on 409, so the existing per-call carve-outs in `api_create` are now redundant but kept for clarity. `Novem409` remains available for callers that want to raise it explicitly.

403s from `api_write` previously raised `Novem403` with no message; they now flow through `raise_on_response` and surface the server message.

## Why draft
This is the **fail-hard** direction from #235 — a behavioral change: writes that previously silently no-op'd on a non-2xx now raise. The open questions there should be settled before this goes ready:
- raise on any non-ok vs 4xx-only (keep 5xx softer/retryable)
- opt-in `raise_on_error`/`strict` flag vs hard default (existing users)
- does it warrant a major version bump

## Verified
Against a live dev API, `mail.bcc = [30 addrs over the 25 cap]` now raises instead of silently storing nothing:

```
NovemException: No recipients were changed, the request contained entries that
could not be applied [user26@example.com: …maximum of 25 external address
recipients … exceeds it.; …]
```

The server-side 400 that makes this observable is `novem-code/gaia#2810`.

## Before ready
- [ ] unit test: 4xx + `rejected` body → raises with the reason
- [ ] resolve the fail-soft/hard direction (#235)

Refs #235 · SDK half of `novem-code/gaia#2656`