### PR TITLE
fix: add request timeouts to prevent indefinite hangs (#239)

### DIFF
--- a/novem/api_ref.py
+++ b/novem/api_ref.py
@@ -133,7 +133,9 @@ class NovemAPI(object):
         self._session = requests.Session()
         self._session.headers.update(get_ua(is_cli))
         self._session.proxies = urllib.request.getproxies()
-        self._session.request = functools.partial(self._session.request, timeout=(10, 120))
+        self._session.request = functools.partial(  # type: ignore[method-assign]
+            self._session.request, timeout=(10, 120)
+        )
 
         if cfg.ignore_ssl:
             # supress ssl warnings

--- a/novem/api_ref.py
+++ b/novem/api_ref.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import sys
 import urllib.request
@@ -132,6 +133,7 @@ class NovemAPI(object):
         self._session = requests.Session()
         self._session.headers.update(get_ua(is_cli))
         self._session.proxies = urllib.request.getproxies()
+        self._session.request = functools.partial(self._session.request, timeout=(10, 120))
 
         if cfg.ignore_ssl:
             # supress ssl warnings

--- a/novem/cli/gql.py
+++ b/novem/cli/gql.py
@@ -6,6 +6,7 @@ while the core data operations remain REST-based.
 """
 
 import datetime
+import functools
 import json
 import re
 import shutil
@@ -35,6 +36,7 @@ class NovemGQL:
         _, config = get_current_config(**connection)
         self._config = config
         self._session = requests.Session()
+        self._session.request = functools.partial(self._session.request, timeout=(10, 120))
         self._debug = debug
         # Support both old gql_debug and new gql parameter for debug mode
         self._gql_debug = gql is True  # True when --gql with no argument

--- a/novem/cli/gql.py
+++ b/novem/cli/gql.py
@@ -36,7 +36,9 @@ class NovemGQL:
         _, config = get_current_config(**connection)
         self._config = config
         self._session = requests.Session()
-        self._session.request = functools.partial(self._session.request, timeout=(10, 120))
+        self._session.request = functools.partial(  # type: ignore[method-assign]
+            self._session.request, timeout=(10, 120)
+        )
         self._debug = debug
         # Support both old gql_debug and new gql parameter for debug mode
         self._gql_debug = gql is True  # True when --gql with no argument

--- a/novem/job/__init__.py
+++ b/novem/job/__init__.py
@@ -415,7 +415,7 @@ class NovemJobAPI(NovemTreeSync, NovemAPI):
             ]
             if self._debug:
                 print(f"  files in:  {len(upload)} ({list(upload.keys())})")
-            r = self._session.post(path, files=multipart, stream=bool(output))
+            r = self._session.post(path, files=multipart, stream=bool(output), timeout=(30, 1800))
         else:
             if self._debug:
                 print("  files in:  0")
@@ -424,6 +424,7 @@ class NovemJobAPI(NovemTreeSync, NovemAPI):
                 headers={"Content-type": "application/json; charset=utf-8"},
                 data="{}",
                 stream=bool(output),
+                timeout=(30, 1800),
             )
 
         if not r.ok:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -5,9 +5,8 @@ from contextlib import redirect_stdout
 from functools import partial
 from unittest.mock import patch
 
-from requests import Response
-
 import pytest
+from requests import Response
 
 from novem import Job
 from novem.exceptions import Novem403, Novem404

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -5,6 +5,8 @@ from contextlib import redirect_stdout
 from functools import partial
 from unittest.mock import patch
 
+from requests import Response
+
 import pytest
 
 from novem import Job
@@ -1015,3 +1017,48 @@ def test_dedup_path_with_conflicts(tmp_path):
 
     open(tmp_path / "file (1).txt", "w").close()
     assert _Job._dedup_path(str(tmp_path), "file.txt") == os.path.join(str(tmp_path), "file (2).txt")
+
+
+# ---------------------------------------------------------------------------
+# timeout tests
+# ---------------------------------------------------------------------------
+
+
+def _ok_response(content=b""):
+    r = Response()
+    r.status_code = 200
+    r._content = content
+    return r
+
+
+def test_session_default_timeout(requests_mock):
+    """Default (10, 120) timeout reaches session.send for ordinary API calls."""
+    j, _ = _make_job(requests_mock)
+
+    with patch.object(j._session, "send", return_value=_ok_response(b"ok")) as mock_send:
+        j.api_read("/log")
+
+    assert mock_send.call_args.kwargs.get("timeout") == (10, 120)
+
+
+def test_job_run_no_files_uses_job_timeout(requests_mock):
+    """run() without files passes timeout=(30, 1800) through to session.send."""
+    j, _ = _make_job(requests_mock)
+
+    with patch.object(j._session, "send", return_value=_ok_response()) as mock_send:
+        j.run()
+
+    assert mock_send.call_args.kwargs.get("timeout") == (30, 1800)
+
+
+def test_job_run_with_files_uses_job_timeout(requests_mock, tmp_path):
+    """run() with files passes timeout=(30, 1800) through to session.send."""
+    j, _ = _make_job(requests_mock)
+
+    f1 = tmp_path / "data.csv"
+    f1.write_text("a,b\n1,2\n")
+
+    with patch.object(j._session, "send", return_value=_ok_response()) as mock_send:
+        j.run(files=[f"@{f1}"])
+
+    assert mock_send.call_args.kwargs.get("timeout") == (30, 1800)


### PR DESCRIPTION
## Summary

- Set a default `(10s connect, 2min read)` timeout on every `requests.Session` via `functools.partial` on `session.request` — one line in `NovemAPI.__init__` covers all subclasses with no per-call-site changes
- `job.run()` overrides to `(30s connect, 30min read)` since job execution can legitimately take up to 30 minutes
- Applied the same fix to `NovemGQL` which manages its own session independently and was not covered by the `NovemAPI` change

## How it works

```python
self._session.request = functools.partial(self._session.request, timeout=(10, 120))
```

`functools.partial` keyword arguments are overridable at call time, so `job.run()` can pass `timeout=(30, 1800)` and it takes precedence over the default.

## Test plan

- `test_session_default_timeout` — mocks `session.send` and verifies the default `(10, 120)` timeout flows through the full chain (`functools.partial` → `session.request` → `session.send`) for an ordinary API call
- `test_job_run_no_files_uses_job_timeout` — same approach, verifies `(30, 1800)` for the empty-JSON branch of `run()`
- `test_job_run_with_files_uses_job_timeout` — same for the multipart-upload branch of `run()`

Closes #239