### PR TITLE
deps: mark pyreadline3 as Windows-only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "requests>=2.32.4",
-    "pyreadline3>=3.5.4",
+    "pyreadline3>=3.5.4 ; os_name == 'nt'",
     "colorama>=0.4.6",
     "urllib3>=2.5.0",
     "typing-extensions>=4.14.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1293,7 +1293,7 @@ version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "colorama" },
-    { name = "pyreadline3" },
+    { name = "pyreadline3", marker = "os_name == 'nt'" },
     { name = "requests" },
     { name = "typing-extensions" },
     { name = "urllib3" },
@@ -1328,7 +1328,7 @@ dev = [
 requires-dist = [
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0,<2" },
-    { name = "pyreadline3", specifier = ">=3.5.4" },
+    { name = "pyreadline3", marker = "os_name == 'nt'", specifier = ">=3.5.4" },
     { name = "python-socketio", extras = ["asyncio-client"], marker = "extra == 'events'", specifier = ">=5.11.0" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "typing-extensions", specifier = ">=4.14.1" },


### PR DESCRIPTION
`pyreadline3` is only imported when `os.name == "nt"` (see `novem/cli/__init__.py`), where it stands in for the stdlib `readline` module that isn't available on Windows. On Linux/macOS the stdlib `readline` is used and `pyreadline3` is never touched.

This adds an `os_name == 'nt'` environment marker to the dependency so it is no longer installed on non-Windows platforms.

- `pyproject.toml`: `"pyreadline3>=3.5.4 ; os_name == 'nt'"`
- `uv.lock`: regenerated; `uv lock --check` passes

No behavior change — the import was already guarded by the `os.name` check.