### PR TITLE
build(deps): constrain mcp extra to <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,10 @@ events = [
     "python-socketio[asyncio_client]>=5.11.0",
 ]
 mcp = [
-    "mcp>=1.0.0",
+    # novem.comments.MCP() targets the v1 API (mcp.server.fastmcp.FastMCP,
+    # Tool.inputSchema).  mcp 2.0 removed both, so keep the extra on 1.x
+    # until the migration lands -- see the tracking issue.
+    "mcp>=1.0.0,<2",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1330,7 +1330,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "colorama", specifier = ">=0.4.6" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0,<2" },
     { name = "pyreadline3", specifier = ">=3.5.4" },
     { name = "python-socketio", extras = ["asyncio-client"], marker = "extra == 'events'", specifier = ">=5.11.0" },
     { name = "requests", specifier = ">=2.32.4" },


### PR DESCRIPTION
Counter-proposal to #263, which bumps `mcp` to 2.0.0 in the lockfile.

`novem.comments.MCP()` cannot run on mcp 2.0. The extra is currently declared as `mcp>=1.0.0` with no upper bound, so `pip install novem[mcp]` has been resolving to 2.0.0 since it was published on 2026-07-28 — this is already broken for users of the released 0.6.1, not just in CI.

The failure mode is misleading. `_check_mcp_deps()` catches bare `ImportError`, and `ModuleNotFoundError` is a subclass, so a user who has mcp installed gets told to install it:

```
ImportError: The "mcp" extra is required. Install with: pip install novem[mcp]
```

### What changes

`mcp>=1.0.0` → `mcp>=1.0.0,<2`. The resolved version in `uv.lock` stays at 1.28.1; only the constraint metadata moves.

### Verification

Installed the extra at the pinned version and exercised the real code path:

```
server: novem-comments (plots/dash)
api_tools -> 6 tools
  - novem_get_thread_context | novem_list_topics | novem_get_topic
  - novem_get_vis_info | novem_get_vis_screenshot | novem_reply
```

690 tests pass, 4 skipped.

This is a stopgap so new installs work again. The v2 migration is tracked separately — see the follow-up issue.
