### PR TITLE
lib: native content API for spaces

### DIFF
--- a/novem/code/__init__.py
+++ b/novem/code/__init__.py
@@ -13,7 +13,7 @@ subclasses set ``_collection``/``_label`` and add their own properties.
 """
 
 import sys
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from novem.exceptions import Novem403, Novem404, raise_on_response
 
@@ -23,6 +23,7 @@ from ..sync import NovemTreeSync
 from ..tags import NovemTags
 from ..utils import cl
 from ..utils import colors as clrs
+from .space_content import SpaceChange, SpaceContent, SpaceDir, SpaceEntry, SpaceFileInfo, space_changes
 
 
 class NovemCodeConfig:
@@ -435,16 +436,36 @@ class NovemCodeAPI(NovemTreeSync, NovemAPI):
 class Space(NovemCodeAPI):
     """A novem space — cloud file storage under ``code/spaces/{id}``.
 
-    File content lives under ``content/*`` and is reachable through
-    ``api_read``/``api_write``/``api_delete`` with a ``/content/...`` path.
+    File content is exposed as a path-indexed mapping on :attr:`content`::
+
+        s = Space("my-space")
+        body = s.content["path/to/document.json"]   # read (str)
+        s.content["reports/q3.csv"] = csv_string     # write
+        for entry in s.content["docs/"]:             # navigate folders
+            ...
+
+    See :mod:`novem.code.space_content` for the full surface (bytes,
+    stat, mkdir, move, remove, walk) and :meth:`changes` for the journal.
     """
 
     _collection = "spaces"
     _label = "space"
 
+    content: "SpaceContent"
+
     def __init__(self, id: str, **kwargs: Any) -> None:
         self.id = id
         super().__init__(**kwargs)
+        self.content = SpaceContent(self)
+
+    def changes(self, since: int = 0) -> Iterator["SpaceChange"]:
+        """Iterate the space's change journal, oldest first, auto-paging.
+
+        Each :class:`SpaceChange` carries ``seq``, ``path``, ``change``
+        (create/update/move/delete), ``old_path`` for moves, ``etag`` and
+        ``size_bytes``. Resume by passing the highest ``seq`` processed.
+        """
+        return space_changes(self, since=since)
 
 
 class Computer(NovemCodeAPI):
@@ -513,4 +534,15 @@ class Image(NovemCodeAPI):
         return self.api_read("/config/repo").strip()
 
 
-__all__ = ["NovemCodeAPI", "NovemCodeConfig", "Space", "Computer", "Image"]
+__all__ = [
+    "NovemCodeAPI",
+    "NovemCodeConfig",
+    "Space",
+    "Computer",
+    "Image",
+    "SpaceContent",
+    "SpaceDir",
+    "SpaceEntry",
+    "SpaceFileInfo",
+    "SpaceChange",
+]

--- a/novem/code/__init__.py
+++ b/novem/code/__init__.py
@@ -23,7 +23,7 @@ from ..sync import NovemTreeSync
 from ..tags import NovemTags
 from ..utils import cl
 from ..utils import colors as clrs
-from .space_content import SpaceChange, SpaceContent, SpaceDir, SpaceEntry, SpaceFileInfo, space_changes
+from .space_content import SpaceChange, SpaceContent, SpaceDir, SpaceEntry, SpaceFileInfo, SpacePath, space_changes
 
 
 class NovemCodeConfig:
@@ -444,6 +444,10 @@ class Space(NovemCodeAPI):
         for entry in s.content["docs/"]:             # navigate folders
             ...
 
+        path = s / "path/to/document.json"           # pathlib-style view
+        path.content = "new content"
+        print(path.size)
+
     See :mod:`novem.code.space_content` for the full surface (bytes,
     stat, mkdir, move, remove, walk) and :meth:`changes` for the journal.
     """
@@ -457,6 +461,10 @@ class Space(NovemCodeAPI):
         self.id = id
         super().__init__(**kwargs)
         self.content = SpaceContent(self)
+
+    def __truediv__(self, path: str) -> "SpacePath":
+        """Return a pathlib-inspired view of ``path`` in this space."""
+        return SpacePath(self.content, path)
 
     def changes(self, since: int = 0) -> Iterator["SpaceChange"]:
         """Iterate the space's change journal, oldest first, auto-paging.
@@ -541,6 +549,7 @@ __all__ = [
     "Computer",
     "Image",
     "SpaceContent",
+    "SpacePath",
     "SpaceDir",
     "SpaceEntry",
     "SpaceFileInfo",

--- a/novem/code/space_content.py
+++ b/novem/code/space_content.py
@@ -1,0 +1,399 @@
+"""Native content access for novem spaces.
+
+A space is cloud file storage under ``code/spaces/{id}``; files and folders
+live under its ``content/`` tree. :class:`SpaceContent` exposes that tree as
+a path-indexed mapping on ``Space.content``:
+
+    s = Space("my-space")
+
+    body = s.content["path/to/document.json"]     # read a file (str)
+    s.content["reports/q3.csv"] = csv_string       # write (create or replace)
+    del s.content["old/tmp.txt"]                   # delete
+    "path/to/document.json" in s.content           # existence
+
+    docs = s.content["docs/"]                      # trailing slash: a folder
+    for entry in docs:                             # SpaceEntry records
+        print(entry.name, entry.kind, entry.size)
+
+Text in, text out by default (UTF-8), matching the rest of the library;
+``read_bytes``/``write_bytes`` handle binary content. Explicit methods
+expose the API's optimistic-concurrency machinery (``if_match`` /
+``no_clobber``) for careful writers — plain dict assignment is
+last-write-wins.
+"""
+
+import json
+import mimetypes
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
+from urllib.parse import quote
+
+from novem.exceptions import Novem403, Novem404, NovemException, raise_on_response
+
+if TYPE_CHECKING:
+    from . import NovemCodeAPI
+
+
+def _norm(path: str) -> str:
+    """Normalise a content path: the leading slash is optional."""
+    return path.lstrip("/")
+
+
+@dataclass
+class SpaceFileInfo:
+    """Metadata for a single content path (no body download)."""
+
+    kind: str  # 'file' | 'dir'
+    name: str
+    path: str
+    size: Optional[int] = None
+    content_type: Optional[str] = None
+    etag: Optional[str] = None
+    created_on: Optional[str] = None
+    last_modified: Optional[str] = None
+
+
+@dataclass
+class SpaceEntry:
+    """One row of a folder listing."""
+
+    name: str
+    kind: str  # 'file' | 'dir'
+    path: str  # full path within the space ('' prefixed dirs end with /)
+    size: Optional[int] = None
+    content_type: Optional[str] = None
+    etag: Optional[str] = None
+    created_on: Optional[str] = None
+    last_modified: Optional[str] = None
+
+
+@dataclass
+class SpaceChange:
+    """One entry of the space's change journal."""
+
+    seq: int
+    path: str
+    change: str  # 'create' | 'update' | 'move' | 'delete'
+    type: Optional[str] = None  # 'file' | 'dir'
+    old_path: Optional[str] = None  # set for moves (and delete tombstones)
+    etag: Optional[str] = None
+    size_bytes: Optional[int] = None
+    created_on: Optional[str] = None
+
+
+class SpaceDir:
+    """A navigable view over one folder in the space.
+
+    Iterating yields :class:`SpaceEntry` records; indexing resolves paths
+    relative to this folder (so ``s.content["docs/"]["report.json"]`` reads
+    ``docs/report.json``).
+    """
+
+    def __init__(self, content: "SpaceContent", path: str) -> None:
+        # '' for the root, otherwise 'some/dir/' (always trailing slash)
+        self._content = content
+        self._path = path
+
+    def __repr__(self) -> str:
+        return f"SpaceDir({self._path or '/'!r})"
+
+    def ls(self) -> List[SpaceEntry]:
+        return self._content.ls(self._path or "/")
+
+    def __iter__(self) -> Iterator[SpaceEntry]:
+        return iter(self.ls())
+
+    def __contains__(self, rel: str) -> bool:
+        return f"{self._path}{_norm(rel)}" in self._content
+
+    def __getitem__(self, rel: str) -> Union[str, "SpaceDir"]:
+        return self._content[f"{self._path}{_norm(rel)}"]
+
+    def __setitem__(self, rel: str, value: Union[str, bytes]) -> None:
+        self._content[f"{self._path}{_norm(rel)}"] = value
+
+    def __delitem__(self, rel: str) -> None:
+        del self._content[f"{self._path}{_norm(rel)}"]
+
+    @property
+    def files(self) -> List[SpaceEntry]:
+        return [e for e in self.ls() if e.kind == "file"]
+
+    @property
+    def dirs(self) -> List[SpaceEntry]:
+        return [e for e in self.ls() if e.kind == "dir"]
+
+
+class SpaceContent:
+    """The ``content/`` tree of a space as a path-indexed mapping."""
+
+    def __init__(self, api: "NovemCodeAPI") -> None:
+        self._api = api
+
+    # -- transport ---------------------------------------------------------
+
+    def _url(self, path: str) -> str:
+        path = _norm(path)
+        return self._api._path("/content" + (f"/{quote(path, safe='/')}" if path else ""))
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        headers: Optional[Dict[str, str]] = None,
+        data: Optional[bytes] = None,
+        params: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        url = self._url(path)
+
+        if self._api._debug:
+            print(f"{method}: {url}")
+
+        r = self._api._session.request(method, url, headers=headers, data=data, params=params)
+
+        if r.status_code == 404:
+            raise Novem404(f"{path or '/'}")
+        if r.status_code == 403:
+            raise Novem403(f"{path or '/'}")
+        if not r.ok:
+            raise_on_response(r)
+
+        return r
+
+    # -- mapping interface ---------------------------------------------------
+
+    def __getitem__(self, path: str) -> Union[str, SpaceDir]:
+        npath = _norm(path)
+        if npath == "" or npath.endswith("/"):
+            return SpaceDir(self, npath)
+        return self.read(npath)
+
+    def __setitem__(self, path: str, value: Union[str, bytes]) -> None:
+        if isinstance(value, bytes):
+            self.write_bytes(path, value)
+        else:
+            self.write(path, value)
+
+    def __delitem__(self, path: str) -> None:
+        self.remove(path)
+
+    def __contains__(self, path: str) -> bool:
+        try:
+            self.stat(path)
+            return True
+        except Novem404:
+            return False
+
+    def get(self, path: str, default: Optional[str] = None) -> Union[str, SpaceDir, None]:
+        """Like ``[]`` but returns ``default`` instead of raising Novem404."""
+        try:
+            return self[path]
+        except Novem404:
+            return default
+
+    # -- reads ---------------------------------------------------------------
+
+    def read(self, path: str) -> str:
+        """Read a file's content as text (UTF-8)."""
+        return self.read_bytes(path).decode("utf-8")
+
+    def read_bytes(self, path: str) -> bytes:
+        """Read a file's content as raw bytes."""
+        r = self._request("GET", path)
+        # a folder listing is JSON, not file content — nudge towards the
+        # trailing-slash convention instead of returning it as a body
+        if r.headers.get("X-NVM-Type") == "dir":
+            raise NovemException(f'"{_norm(path)}" is a folder — index it with a trailing slash: "{_norm(path)}/"')
+        return r.content
+
+    def stat(self, path: str) -> SpaceFileInfo:
+        """Metadata for a path without downloading the body."""
+        npath = _norm(path).rstrip("/")
+        r = self._request("GET", npath, headers={"Accept": "application/json"})
+        meta = r.json()
+        if isinstance(meta, list):
+            # folders answer with their listing
+            name = npath.rsplit("/", 1)[-1] if npath else "/"
+            return SpaceFileInfo(kind="dir", name=name, path=npath)
+        return SpaceFileInfo(
+            kind=meta.get("kind", "file"),
+            name=meta.get("name", ""),
+            path=meta.get("path", npath),
+            size=meta.get("size"),
+            content_type=meta.get("content_type"),
+            etag=meta.get("etag"),
+            created_on=meta.get("created_on"),
+            last_modified=meta.get("last_modified"),
+        )
+
+    def ls(self, path: str = "/") -> List[SpaceEntry]:
+        """List a folder (default: the content root)."""
+        npath = _norm(path).rstrip("/")
+        r = self._request("GET", npath)
+        rows = r.json()
+        if not isinstance(rows, list):
+            raise NovemException(f'"{npath}" is a file, not a folder')
+
+        prefix = f"{npath}/" if npath else ""
+        out = []
+        for row in rows:
+            kind = "dir" if row.get("type") == "dir" else "file"
+            out.append(
+                SpaceEntry(
+                    name=row.get("name", ""),
+                    kind=kind,
+                    path=f'{prefix}{row.get("name", "")}' + ("/" if kind == "dir" else ""),
+                    size=row.get("size"),
+                    content_type=row.get("content_type"),
+                    etag=row.get("ETag") or row.get("etag"),
+                    created_on=row.get("created_on"),
+                    last_modified=row.get("last_modified"),
+                )
+            )
+        return out
+
+    def walk(self, top: str = "/") -> Iterator[Tuple[str, List[str], List[str]]]:
+        """Walk the tree like ``os.walk``: yields (path, dirnames, filenames).
+
+        ``path`` is '' for the root, otherwise 'some/dir/'.
+        """
+        npath = _norm(top).rstrip("/")
+        prefix = f"{npath}/" if npath else ""
+        entries = self.ls(npath or "/")
+        dirs = [e.name for e in entries if e.kind == "dir"]
+        files = [e.name for e in entries if e.kind == "file"]
+        yield (prefix, dirs, files)
+        for d in dirs:
+            yield from self.walk(f"{prefix}{d}")
+
+    # -- writes ---------------------------------------------------------------
+
+    def write(
+        self,
+        path: str,
+        data: Union[str, bytes],
+        if_match: Optional[str] = None,
+        no_clobber: bool = False,
+        content_type: Optional[str] = None,
+    ) -> None:
+        """Write a file (create or replace); parent folders are auto-created.
+
+        ``if_match`` writes only when the file's current ETag matches;
+        ``no_clobber`` refuses to replace an existing file. Both surface a
+        412 as a NovemException when the condition fails.
+        """
+        npath = _norm(path)
+        if npath.endswith("/"):
+            raise NovemException("write() takes a file path — use mkdir() for folders")
+
+        body = data.encode("utf-8") if isinstance(data, str) else data
+        headers: Dict[str, str] = {
+            "Content-Type": content_type
+            or mimetypes.guess_type(npath)[0]
+            or ("text/plain" if isinstance(data, str) else "application/octet-stream")
+        }
+        if if_match:
+            headers["If-Match"] = if_match
+        if no_clobber:
+            headers["If-None-Match"] = "*"
+
+        self._request("PUT", npath, headers=headers, data=body)
+
+    def write_bytes(
+        self,
+        path: str,
+        data: bytes,
+        if_match: Optional[str] = None,
+        no_clobber: bool = False,
+        content_type: Optional[str] = None,
+    ) -> None:
+        """Write raw bytes to a file (see :meth:`write`)."""
+        self.write(path, data, if_match=if_match, no_clobber=no_clobber, content_type=content_type)
+
+    def mkdir(self, path: str) -> None:
+        """Create a folder (idempotent; parents are auto-created)."""
+        npath = _norm(path).rstrip("/")
+        if not npath:
+            return
+        # PUT with a trailing slash is the folder-create form
+        url = self._api._path(f"/content/{quote(npath, safe='/')}/")
+        r = self._api._session.put(url)
+        if r.status_code == 404:
+            raise Novem404(npath)
+        if r.status_code == 403:
+            raise Novem403(npath)
+        if not r.ok:
+            raise_on_response(r)
+
+    def move(
+        self,
+        src: str,
+        dst: str,
+        if_match: Optional[str] = None,
+        no_clobber: bool = False,
+    ) -> None:
+        """Rename or move a file or folder tree (atomic, metadata-only).
+
+        Matches POSIX ``mv``: an existing file destination is replaced,
+        a folder destination is never replaced. ``no_clobber`` refuses to
+        replace anything; ``if_match`` guards the source's ETag.
+        """
+        headers = {"Content-Type": "application/json"}
+        if if_match:
+            headers["If-Match"] = if_match
+        if no_clobber:
+            headers["If-None-Match"] = "*"
+
+        self._request("PATCH", _norm(src), headers=headers, data=json.dumps({"to": _norm(dst)}).encode("utf-8"))
+
+    def remove(self, path: str, recursive: bool = False) -> None:
+        """Delete a file or folder; non-empty folders need ``recursive``."""
+        params = {"recursive": "true"} if recursive else None
+        self._request("DELETE", _norm(path).rstrip("/"), params=params)
+
+
+def space_changes(
+    api: "NovemCodeAPI",
+    since: int = 0,
+    batch: int = 1000,
+) -> Iterator[SpaceChange]:
+    """Iterate the space's change journal, oldest first, auto-paging.
+
+    Resume by passing the highest ``seq`` you have processed as ``since``.
+    """
+    while True:
+        url = api._path("/changes")
+        r = api._session.get(url, params={"since": str(since), "limit": str(batch)})
+        if r.status_code == 404:
+            raise Novem404("changes")
+        if r.status_code == 403:
+            raise Novem403("changes")
+        if not r.ok:
+            raise_on_response(r)
+
+        payload = r.json()
+        for row in payload.get("changes", []):
+            yield SpaceChange(
+                seq=row.get("seq", 0),
+                path=row.get("path", ""),
+                change=row.get("change", ""),
+                type=row.get("type"),
+                old_path=row.get("old_path"),
+                etag=row.get("etag"),
+                size_bytes=row.get("size_bytes"),
+                created_on=row.get("created_on"),
+            )
+            since = max(since, row.get("seq", 0))
+
+        if not payload.get("has_more"):
+            return
+
+
+__all__ = [
+    "SpaceContent",
+    "SpaceDir",
+    "SpaceEntry",
+    "SpaceFileInfo",
+    "SpaceChange",
+    "space_changes",
+]

--- a/novem/code/space_content.py
+++ b/novem/code/space_content.py
@@ -15,6 +15,14 @@ a path-indexed mapping on ``Space.content``:
     for entry in docs:                             # SpaceEntry records
         print(entry.name, entry.kind, entry.size)
 
+The same tree also has a pathlib-inspired object interface via ``Space / path``:
+
+    document = s / "path/to/document.json"
+    body = document.content
+    document.content = '{"a": 2}'
+    print(document.size)
+    document.unlink()
+
 Text in, text out by default (UTF-8), matching the rest of the library;
 ``read_bytes``/``write_bytes`` handle binary content. Explicit methods
 expose the API's optimistic-concurrency machinery (``if_match`` /
@@ -122,6 +130,65 @@ class SpaceDir:
     @property
     def dirs(self) -> List[SpaceEntry]:
         return [e for e in self.ls() if e.kind == "dir"]
+
+
+class SpacePath:
+    """A pathlib-inspired view of one path in a space.
+
+    Paths can be constructed in one step or joined incrementally::
+
+        report = space / "reports" / "q3.csv"
+
+    Reading or assigning :attr:`content`, inspecting :attr:`size`, and
+    removing the path delegate to the same :class:`SpaceContent` API exposed
+    on ``space.content``.
+    """
+
+    def __init__(self, content: "SpaceContent", path: str) -> None:
+        self._space_content = content
+        self._path = _norm(path)
+
+    def __repr__(self) -> str:
+        return f"SpacePath({self._path!r})"
+
+    def __str__(self) -> str:
+        return self._path
+
+    def __truediv__(self, child: str) -> "SpacePath":
+        base = self._path.rstrip("/")
+        rel = _norm(child)
+        return SpacePath(self._space_content, f"{base}/{rel}" if base else rel)
+
+    @property
+    def path(self) -> str:
+        """The path relative to the root of the space."""
+        return self._path
+
+    @property
+    def content(self) -> str:
+        """Read or replace the file's UTF-8 content."""
+        return self._space_content.read(self._path)
+
+    @content.setter
+    def content(self, value: Union[str, bytes]) -> None:
+        self._space_content[self._path] = value
+
+    @property
+    def size(self) -> Optional[int]:
+        """The file size in bytes, without downloading its content."""
+        return self._space_content.stat(self._path).size
+
+    def remove(self, recursive: bool = False) -> None:
+        """Remove this path; non-empty folders require ``recursive=True``."""
+        self._space_content.remove(self._path, recursive=recursive)
+
+    def rm(self, recursive: bool = False) -> None:
+        """Alias for :meth:`remove`."""
+        self.remove(recursive=recursive)
+
+    def unlink(self, recursive: bool = False) -> None:
+        """Alias for :meth:`remove`."""
+        self.remove(recursive=recursive)
 
 
 class SpaceContent:
@@ -391,6 +458,7 @@ def space_changes(
 
 __all__ = [
     "SpaceContent",
+    "SpacePath",
     "SpaceDir",
     "SpaceEntry",
     "SpaceFileInfo",

--- a/tests/test_space_content.py
+++ b/tests/test_space_content.py
@@ -289,6 +289,48 @@ def test_paths_are_url_quoted(requests_mock):
     assert s.content["with space/a file.txt"] == "ok"
 
 
+# --- pathlib-style paths -----------------------------------------------------
+
+
+def test_space_path_content_and_size(requests_mock):
+    s, base = _space(requests_mock)
+    seen = {}
+
+    def on_get(request, context):
+        context.status_code = 200
+        if request.headers.get("Accept") == "application/json":
+            return json.dumps({"kind": "file", "name": "document.json", "size": 123})
+        return '{"a": 1}'
+
+    def on_put(request, context):
+        seen["body"] = request.body
+        seen["content_type"] = request.headers.get("Content-Type")
+        context.status_code = 200
+        return ""
+
+    url = f"{base}/path/to/document.json"
+    requests_mock.register_uri("get", url, text=on_get)
+    requests_mock.register_uri("put", url, text=on_put)
+
+    path = s / "path" / "to/document.json"
+    assert str(path) == "path/to/document.json"
+    assert path.path == "path/to/document.json"
+    assert path.content == '{"a": 1}'
+
+    path.content = "this is new content"
+    assert seen == {"body": b"this is new content", "content_type": "application/json"}
+    assert path.size == 123
+
+
+@pytest.mark.parametrize("method", ["rm", "remove", "unlink"])
+def test_space_path_remove_aliases(requests_mock, method):
+    s, base = _space(requests_mock)
+    requests_mock.register_uri("delete", f"{base}/tmp.txt", status_code=200)
+
+    path = s / "/tmp.txt"
+    getattr(path, method)()
+
+
 # --- change journal ------------------------------------------------------------
 
 

--- a/tests/test_space_content.py
+++ b/tests/test_space_content.py
@@ -1,0 +1,330 @@
+"""Library tests for the native space content API (Space.content)."""
+
+import configparser
+import json
+import os
+
+import pytest
+
+from novem import Space
+from novem.exceptions import Novem404, NovemException
+
+BASE = os.path.dirname(os.path.abspath(__file__))
+CONFIG_FILE = f"{BASE}/test.conf"
+
+
+def _api_root():
+    config = configparser.ConfigParser()
+    config.read(CONFIG_FILE)
+    return config["general"]["api_root"]
+
+
+def _space(requests_mock):
+    api_root = _api_root()
+    requests_mock.register_uri("put", f"{api_root}code/spaces/sp", status_code=201)
+    return Space("sp", config_path=CONFIG_FILE), f"{api_root}code/spaces/sp/content"
+
+
+# --- reads -------------------------------------------------------------------
+
+
+def test_read_str_and_leading_slash(requests_mock):
+    s, base = _space(requests_mock)
+    requests_mock.register_uri("get", f"{base}/path/to/doc.json", content=b'{"a": 1}')
+
+    assert s.content["path/to/doc.json"] == '{"a": 1}'
+    assert s.content["/path/to/doc.json"] == '{"a": 1}'  # leading slash optional
+
+
+def test_read_bytes(requests_mock):
+    s, base = _space(requests_mock)
+    payload = bytes(range(256))
+    requests_mock.register_uri("get", f"{base}/logo.png", content=payload)
+
+    assert s.content.read_bytes("logo.png") == payload
+
+
+def test_read_missing_raises_404_and_get_defaults(requests_mock):
+    s, base = _space(requests_mock)
+    requests_mock.register_uri("get", f"{base}/nope.txt", status_code=404)
+
+    with pytest.raises(Novem404):
+        s.content["nope.txt"]
+    assert s.content.get("nope.txt") is None
+    assert s.content.get("nope.txt", "fallback") == "fallback"
+
+
+def test_reading_a_folder_without_slash_is_guided(requests_mock):
+    s, base = _space(requests_mock)
+    requests_mock.register_uri("get", f"{base}/docs", json=[], headers={"X-NVM-Type": "dir"})
+
+    with pytest.raises(NovemException, match="trailing slash"):
+        s.content["docs"]
+
+
+def test_stat_file(requests_mock):
+    s, base = _space(requests_mock)
+
+    def on_get(request, context):
+        assert request.headers["Accept"] == "application/json"
+        context.status_code = 200
+        return json.dumps(
+            {
+                "kind": "file",
+                "name": "doc.json",
+                "path": "path/doc.json",
+                "size": 42,
+                "content_type": "application/json",
+                "etag": "abc123",
+                "created_on": "Thu, 17 Mar 2022 12:19:02 UTC",
+                "last_modified": "Thu, 17 Mar 2022 12:20:02 UTC",
+            }
+        )
+
+    requests_mock.register_uri("get", f"{base}/path/doc.json", text=on_get)
+
+    info = s.content.stat("path/doc.json")
+    assert info.kind == "file"
+    assert info.size == 42
+    assert info.etag == "abc123"
+    assert info.content_type == "application/json"
+
+
+def test_contains(requests_mock):
+    s, base = _space(requests_mock)
+    requests_mock.register_uri("get", f"{base}/there.txt", json={"kind": "file", "name": "there.txt"})
+    requests_mock.register_uri("get", f"{base}/missing.txt", status_code=404)
+
+    assert "there.txt" in s.content
+    assert "missing.txt" not in s.content
+
+
+# --- folders -----------------------------------------------------------------
+
+LISTING = [
+    {"name": "raw", "type": "dir", "created_on": "Thu, 17 Mar 2022 12:19:02 UTC"},
+    {
+        "name": "q3.csv",
+        "type": "file",
+        "size": 1234,
+        "content_type": "text/csv",
+        "ETag": "e1",
+        "created_on": "Thu, 17 Mar 2022 12:19:02 UTC",
+        "last_modified": "Thu, 17 Mar 2022 12:20:02 UTC",
+    },
+]
+
+
+def test_dir_view_iteration_and_relative_access(requests_mock):
+    s, base = _space(requests_mock)
+    requests_mock.register_uri("get", f"{base}/reports", json=LISTING)
+    requests_mock.register_uri("get", f"{base}/reports/q3.csv", content=b"a,b\n1,2\n")
+
+    reports = s.content["reports/"]
+    names = [(e.name, e.kind) for e in reports]
+    assert names == [("raw", "dir"), ("q3.csv", "file")]
+
+    assert [e.name for e in reports.files] == ["q3.csv"]
+    assert [e.name for e in reports.dirs] == ["raw"]
+    assert reports.files[0].size == 1234
+    assert reports.files[0].etag == "e1"
+    assert reports.files[0].path == "reports/q3.csv"
+    assert reports.dirs[0].path == "reports/raw/"
+
+    # relative indexing from the folder view
+    assert reports["q3.csv"] == "a,b\n1,2\n"
+
+
+def test_root_listing(requests_mock):
+    s, base = _space(requests_mock)
+    requests_mock.register_uri("get", base, json=LISTING)
+
+    root = s.content["/"]
+    assert [e.name for e in root] == ["raw", "q3.csv"]
+    assert [e.name for e in s.content.ls()] == ["raw", "q3.csv"]
+
+
+def test_walk(requests_mock):
+    s, base = _space(requests_mock)
+    requests_mock.register_uri("get", base, json=[{"name": "docs", "type": "dir"}, {"name": "a.txt", "type": "file"}])
+    requests_mock.register_uri(
+        "get", f"{base}/docs", json=[{"name": "deep", "type": "dir"}, {"name": "b.txt", "type": "file"}]
+    )
+    requests_mock.register_uri("get", f"{base}/docs/deep", json=[{"name": "c.txt", "type": "file"}])
+
+    assert list(s.content.walk()) == [
+        ("", ["docs"], ["a.txt"]),
+        ("docs/", ["deep"], ["b.txt"]),
+        ("docs/deep/", [], ["c.txt"]),
+    ]
+
+
+# --- writes ------------------------------------------------------------------
+
+
+def test_write_str_sets_content_type_from_extension(requests_mock):
+    s, base = _space(requests_mock)
+    seen = {}
+
+    def on_put(request, context):
+        seen["body"] = request.body
+        seen["ct"] = request.headers.get("Content-Type")
+        context.status_code = 201
+        return ""
+
+    requests_mock.register_uri("put", f"{base}/doc.json", text=on_put)
+
+    s.content["doc.json"] = '{"a": 1}'
+    assert seen["body"] == b'{"a": 1}'
+    assert seen["ct"] == "application/json"
+
+
+def test_write_bytes(requests_mock):
+    s, base = _space(requests_mock)
+    seen = {}
+
+    def on_put(request, context):
+        seen["body"] = request.body
+        seen["ct"] = request.headers.get("Content-Type")
+        context.status_code = 201
+        return ""
+
+    requests_mock.register_uri("put", f"{base}/blob.bin", text=on_put)
+
+    s.content["blob.bin"] = b"\x00\x01\x02"
+    assert seen["body"] == b"\x00\x01\x02"
+    assert seen["ct"] == "application/octet-stream"
+
+
+def test_write_conditions(requests_mock):
+    s, base = _space(requests_mock)
+    seen = {}
+
+    def on_put(request, context):
+        seen["if_match"] = request.headers.get("If-Match")
+        seen["if_none_match"] = request.headers.get("If-None-Match")
+        context.status_code = 200
+        return ""
+
+    requests_mock.register_uri("put", f"{base}/state.json", text=on_put)
+
+    s.content.write("state.json", "{}", if_match="abc123")
+    assert seen["if_match"] == "abc123"
+
+    s.content.write("state.json", "{}", no_clobber=True)
+    assert seen["if_none_match"] == "*"
+
+
+def test_write_conflict_raises(requests_mock):
+    s, base = _space(requests_mock)
+    requests_mock.register_uri("put", f"{base}/state.json", status_code=412, json={"message": "precondition failed"})
+
+    with pytest.raises(NovemException, match="precondition failed"):
+        s.content.write("state.json", "{}", if_match="stale")
+
+
+def test_write_rejects_folder_path(requests_mock):
+    s, base = _space(requests_mock)
+    with pytest.raises(NovemException, match="mkdir"):
+        s.content.write("docs/", "nope")
+
+
+def test_mkdir_uses_trailing_slash(requests_mock):
+    s, base = _space(requests_mock)
+    seen = {}
+
+    def on_put(request, context):
+        seen["url"] = request.url
+        context.status_code = 201
+        return ""
+
+    requests_mock.register_uri("put", f"{base}/data/raw/", text=on_put)
+
+    s.content.mkdir("data/raw")
+    assert seen["url"].endswith("/content/data/raw/")
+
+
+def test_move(requests_mock):
+    s, base = _space(requests_mock)
+    seen = {}
+
+    def on_patch(request, context):
+        seen["body"] = request.json()
+        seen["no_clobber"] = request.headers.get("If-None-Match")
+        context.status_code = 200
+        return ""
+
+    requests_mock.register_uri("patch", f"{base}/draft.md", text=on_patch)
+
+    s.content.move("draft.md", "published/final.md")
+    assert seen["body"] == {"to": "published/final.md"}
+
+    s.content.move("/draft.md", "final.md", no_clobber=True)
+    assert seen["no_clobber"] == "*"
+
+
+def test_remove_and_recursive(requests_mock):
+    s, base = _space(requests_mock)
+    seen = {}
+
+    def on_delete(request, context):
+        seen["qs"] = request.qs
+        context.status_code = 200
+        return ""
+
+    requests_mock.register_uri("delete", f"{base}/tmp.txt", text=on_delete)
+    requests_mock.register_uri("delete", f"{base}/data", text=on_delete)
+
+    del s.content["tmp.txt"]
+    assert seen["qs"] == {}
+
+    s.content.remove("data/", recursive=True)
+    assert seen["qs"] == {"recursive": ["true"]}
+
+
+def test_paths_are_url_quoted(requests_mock):
+    s, base = _space(requests_mock)
+    requests_mock.register_uri("get", f"{base}/with%20space/a%20file.txt", content=b"ok")
+
+    assert s.content["with space/a file.txt"] == "ok"
+
+
+# --- change journal ------------------------------------------------------------
+
+
+def test_changes_pages_through_journal(requests_mock):
+    api_root = _api_root()
+    requests_mock.register_uri("put", f"{api_root}code/spaces/sp", status_code=201)
+    s = Space("sp", config_path=CONFIG_FILE)
+
+    pages = {
+        "0": {
+            "changes": [
+                {"seq": 1, "path": "a.txt", "change": "create", "type": "file", "etag": "e1"},
+                {"seq": 2, "path": "b.txt", "change": "update", "type": "file", "etag": "e2"},
+            ],
+            "latest_seq": 2,
+            "has_more": True,
+        },
+        "2": {
+            "changes": [
+                {"seq": 3, "path": "c.txt", "change": "move", "type": "file", "old_path": "b.txt"},
+            ],
+            "latest_seq": 3,
+            "has_more": False,
+        },
+    }
+
+    def on_get(request, context):
+        context.status_code = 200
+        return json.dumps(pages[request.qs["since"][0]])
+
+    requests_mock.register_uri("get", f"{api_root}code/spaces/sp/changes", text=on_get)
+
+    changes = list(s.changes())
+    assert [(c.seq, c.change, c.path) for c in changes] == [
+        (1, "create", "a.txt"),
+        (2, "update", "b.txt"),
+        (3, "move", "c.txt"),
+    ]
+    assert changes[2].old_path == "b.txt"


### PR DESCRIPTION
**Stacked on #268** — review only the top commit (`lib: native content API for spaces`); the rest is the CLI PR underneath.

Native Python access to a space's files. `Space.content` is a path-indexed mapping:

```python
from novem import Space

s = Space("my-space")

body = s.content["path/to/document.json"]   # read (str, leading slash optional)
s.content["reports/q3.csv"] = df.to_csv()   # write (create or replace)
del s.content["old/tmp.txt"]                # delete
"path/to/document.json" in s.content        # existence

for entry in s.content["docs/"]:            # trailing slash: a folder view
    print(entry.name, entry.kind, entry.size)
```

- text in, text out by default; `read_bytes`/`write_bytes` for binary (content-type guessed from the extension)
- folder views iterate `SpaceEntry` records, expose `.files`/`.dirs`, and index relative paths; `walk()` covers the whole tree
- `stat()`, `mkdir()`, `move()` (atomic rename, POSIX `mv` semantics), `remove(recursive=True)`
- plain assignment is last-write-wins; `write(path, body, if_match=etag)` / `no_clobber=True` expose optimistic concurrency explicitly
- `s.changes(since=seq)` iterates the change journal oldest-first with automatic paging — the building block for future tree sync

19 new tests; full surface documented in the `novem.code.space_content` docstrings.
