### PR TITLE
cli: run commands and attach a shell on a computer

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -159,11 +159,14 @@ keeps its everyday meaning. Long forms `--space`, `--repo`, `--computer` and
   novem -s space_name -e content/notes.md      # edit in $EDITOR
 
   # create a computer, size it, boot it, watch it
-  novem -c box_name -C --type ephemeral
-  novem -c box_name -w config/cpu 4 -w config/memory 4Gi
+  novem -c box_name -C --image @novem/base -w config/cpu 4 -w config/memory 4Gi
   novem -c box_name -w status online
   novem -c box_name -r status
   novem -c box_name -r log
+
+  # run a command on it, or attach a shell
+  novem -c box_name -R -- ls -la /var/log
+  novem -c box_name -A
 
   # inspect an image built from one of your repos
   novem -i image_name -r status
@@ -173,6 +176,40 @@ keeps its everyday meaning. Long forms `--space`, `--repo`, `--computer` and
 Images are derived from their source repo (one appears whenever a repo has
 been built) and cannot be created or deleted directly — everything else
 (shares, tags, `-w name`, `-r ...`) works like the other resources.
+
+### Running commands and attaching a shell
+`-R` runs a workload and `-A` attaches an interactive shell. Everything after a
+standalone `--` is the invocation to run, passed through verbatim:
+
+```bash
+  # one-off command; arguments survive without shell re-parsing, and the
+  # exit code is the command's own
+  novem -c box_name -R -- python3 -c 'print(1+1)'
+
+  # stdin is piped through
+  cat data.csv | novem -c box_name -R -- wc -l
+
+  # follow a log — a long-running command, not a separate feature
+  novem -c box_name -R -- tail -f /var/log/app.log
+
+  # interactive shell
+  novem -c box_name -A
+```
+
+Both need the computer to be running, and both wait while it finishes booting
+rather than failing immediately. A command killed by a signal reports
+`128 + signal`, the way a shell does.
+
+`--image` follows the same first-selector rule as the short flags: on its own
+it selects an image, and once a resource is selected it sets that resource's
+image.
+
+```bash
+  novem --image                       # list your images
+  novem --image image_name -r status  # inspect one
+  novem -c box_name --image @novem/base   # set the computer's image
+  novem -c box_name --image               # read it back
+```
 
 Because plot/grid/mail/doc/job selectors always win, existing invocations are
 unchanged: `novem -p plot_name -s public -C` still shares a plot, and

--- a/CLI.md
+++ b/CLI.md
@@ -128,7 +128,7 @@ The other three do double duty:
 |------|-----------|----------------------------------|
 | `-s` | spaces    | share group (`-s public -C`)     |
 | `-r` | repos     | read path to stdout (`-r url`)   |
-| `-i` | images    | `--input` upload dir (with `-R`) |
+| `-i` | images    | `--input` job input files/dirs (with `-R`) |
 
 The rule: when nothing else claims the invocation (no `-p`/`-g`/`-m`/`-d`/`-j`/
 `-c` selector and no standalone command like `--init` or `--get`), the *first*
@@ -199,6 +199,21 @@ standalone `--` is the invocation to run, passed through verbatim:
 Both need the computer to be running, and both wait while it finishes booting
 rather than failing immediately. A command killed by a signal reports
 `128 + signal`, the way a shell does.
+
+### Job inputs and outputs
+`-R` triggers a job run; files travel on `-i` and `-o`. An `@` prefix means one
+file, a bare path means a directory, and both are repeatable:
+
+```bash
+  novem -j job_name -R -i @prices.csv          # send one file
+  novem -j job_name -R -i ./inputs             # send a directory
+  novem -j job_name -R -i @a.csv -i @b.csv     # several
+  novem -j job_name -R -o @chart.png           # write the output to this file
+  novem -j job_name -R -o ./out                # write it into this directory
+```
+
+`-i @file` replaces the old `-R @file` form, so that `-R`'s own arguments can
+carry run parameters in a future release.
 
 `--image` follows the same first-selector rule as the short flags: on its own
 it selects an image, and once a resource is selected it sets that resource's

--- a/CLI.md
+++ b/CLI.md
@@ -178,6 +178,7 @@ been built) and cannot be created or deleted directly — everything else
 (shares, tags, `-w name`, `-r ...`) works like the other resources.
 
 ### Running commands and attaching a shell
+
 `-R` runs a workload and `-A` attaches an interactive shell. Everything after a
 standalone `--` is the invocation to run, passed through verbatim:
 
@@ -200,7 +201,11 @@ Both need the computer to be running, and both wait while it finishes booting
 rather than failing immediately. A command killed by a signal reports
 `128 + signal`, the way a shell does.
 
+Live computer connections use the optional compute dependencies. Install them
+with `pip install 'novem[compute]'` when installing the library directly.
+
 ### Job inputs and outputs
+
 `-R` triggers a job run; files travel on `-i` and `-o`. An `@` prefix means one
 file, a bare path means a directory, and both are repeatable:
 

--- a/CLI.md
+++ b/CLI.md
@@ -198,8 +198,9 @@ standalone `--` is the invocation to run, passed through verbatim:
 ```
 
 Both need the computer to be running, and both wait while it finishes booting
-rather than failing immediately. A command killed by a signal reports
-`128 + signal`, the way a shell does.
+rather than failing immediately. Set the wait with `--connect-timeout SECONDS`.
+A command killed by a signal reports `128 + signal`, the way a shell does;
+the first local Ctrl-C is forwarded to the command and a second exits locally.
 
 Live computer connections use the optional compute dependencies. Install them
 with `pip install 'novem[compute]'` when installing the library directly.

--- a/novem/api_ref.py
+++ b/novem/api_ref.py
@@ -123,6 +123,7 @@ class NovemAPI(object):
     """
 
     id: Optional[str] = None
+    token: Optional[str] = None
     _type: Optional[str] = None
     _qpr: Optional[str] = None
 

--- a/novem/cli/__init__.py
+++ b/novem/cli/__init__.py
@@ -472,6 +472,17 @@ def run_cli_wrapped() -> None:
         print(f"novem {__version__}")
         return
 
+    if args.get("attach") and not args.get("computer"):
+        other_resource = any(args.get(key) for key in ("plot", "grid", "mail", "doc", "job", "space", "repo", "image"))
+        if other_resource:
+            print("novem: -A is only available for computers", file=sys.stderr)
+        else:
+            print("novem: -A requires a named computer, e.g. novem -c <name> -A", file=sys.stderr)
+        sys.exit(1)
+    if args.get("run_job") is not None and not (args.get("computer") or args.get("job")):
+        print("novem: -R requires a named computer or job", file=sys.stderr)
+        sys.exit(1)
+
     if args and "debug" in args and args["debug"]:
         """
         Print some sytem information

--- a/novem/cli/args.py
+++ b/novem/cli/args.py
@@ -29,6 +29,7 @@ CliArgs = TypedDict(
         "repo": str,
         "computer": str,
         "image": str,
+        "image_ref": Optional[str],
         "invite": str,
         # group subcommand (only present for `novem group ...`)
         "org": Optional[str],
@@ -83,6 +84,8 @@ CliArgs = TypedDict(
         "init": Optional[str],
         "invite_user": Optional[str],
         "run_job": Optional[List[str]],  # nargs="*"
+        "argv": Optional[List[str]],  # the tail after `--`
+        "attach": bool,
         "events": Optional[List[str]],  # nargs="+"
         # raw http (post/put take PATH [DATA] -> nargs="+")
         "http_get": Optional[str],

--- a/novem/cli/args.py
+++ b/novem/cli/args.py
@@ -74,7 +74,7 @@ CliArgs = TypedDict(
         # io / tree dump-load
         "dump": Optional[str],
         "load": Optional[str],
-        "input": Optional[str],
+        "input": Optional[List[List[str]]],  # -w, action="append", nargs="+"
         "input_dir": Optional[List[str]],  # action="append"
         "output_dir": Optional[List[str]],  # action="append"
         "out": Optional[str],

--- a/novem/cli/args.py
+++ b/novem/cli/args.py
@@ -86,6 +86,7 @@ CliArgs = TypedDict(
         "run_job": Optional[List[str]],  # nargs="*"
         "argv": Optional[List[str]],  # the tail after `--`
         "attach": bool,
+        "connect_timeout": float,
         "events": Optional[List[str]],  # nargs="+"
         # raw http (post/put take PATH [DATA] -> nargs="+")
         "http_get": Optional[str],

--- a/novem/cli/args.py
+++ b/novem/cli/args.py
@@ -75,8 +75,8 @@ CliArgs = TypedDict(
         "dump": Optional[str],
         "load": Optional[str],
         "input": Optional[str],
-        "input_dir": Optional[str],
-        "output_dir": Optional[str],
+        "input_dir": Optional[List[str]],  # action="append"
+        "output_dir": Optional[List[str]],  # action="append"
         "out": Optional[str],
         "edit": Optional[str],
         "filter": Optional[List[str]],  # action="append"

--- a/novem/cli/common.py
+++ b/novem/cli/common.py
@@ -678,12 +678,15 @@ def code_resource(args: CliArgs, kind: str) -> None:
             obj.api_write("/config/image", image_ref)
 
         found_stdin = False
-        stdin_data = data_on_stdin()
+        inputs = args["input"] or []
+        # Leave piped data untouched unless a bare -w PATH needs it. Computer
+        # commands consume stdin later, when the live session starts.
+        stdin_data = data_on_stdin() if any(len(item) == 1 for item in inputs) else None
         stdin_has_data = bool(stdin_data)
 
         # check if we have any explicit inputs [-w's]
-        if args["input"] and len(args["input"]):
-            for i in args["input"]:
+        if inputs:
+            for i in inputs:
                 path = f"/{i[0]}"
 
                 if len(i) == 1:

--- a/novem/cli/common.py
+++ b/novem/cli/common.py
@@ -3,7 +3,7 @@ import sys
 from typing import Any, Dict, Literal, Optional, cast
 
 from novem import Computer, Doc, Grid, Image, Job, Mail, Plot, Repo, Space
-from novem.api_ref import Novem404, NovemAPI
+from novem.api_ref import Novem404, NovemAPI, NovemException
 from novem.cli.config import config_from_args
 from novem.cli.editor import edit
 from novem.cli.gql import NovemGQL, _build_var_lookup, _fetch_vde_topics_gql, render_topics
@@ -22,7 +22,7 @@ from novem.cli.vis import (
     list_vis_tags,
 )
 from novem.code import NovemCodeAPI
-from novem.utils import API_ROOT, data_on_stdin
+from novem.utils import API_ROOT, data_on_stdin, stream_on_stdin
 from novem.vis import NovemVisAPI
 
 from .args import CliArgs
@@ -671,7 +671,8 @@ def code_resource(args: CliArgs, kind: str) -> None:
         # --image REF sets config/image; a bare --image reads it back, the
         # same way a bare -s lists shares and a bare -t lists tags
         image_ref = args.get("image_ref")
-        if image_ref is None:
+        has_session = args.get("run_job") is not None or args.get("attach")
+        if image_ref is None and not has_session:
             print(obj.api_read("/config/image"), end="")
             return
         elif image_ref:
@@ -679,9 +680,16 @@ def code_resource(args: CliArgs, kind: str) -> None:
 
         found_stdin = False
         inputs = args["input"] or []
+        bare_inputs = any(len(item) == 1 for item in inputs)
+        if bare_inputs and has_session:
+            print(
+                "novem: bare -w and -R/-A cannot both read stdin; provide a value or @file to -w",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         # Leave piped data untouched unless a bare -w PATH needs it. Computer
         # commands consume stdin later, when the live session starts.
-        stdin_data = data_on_stdin() if any(len(item) == 1 for item in inputs) else None
+        stdin_data = data_on_stdin() if bare_inputs else None
         stdin_has_data = bool(stdin_data)
 
         # check if we have any explicit inputs [-w's]
@@ -768,7 +776,7 @@ def _computer_session(args: CliArgs, obj: NovemCodeAPI, kind: str) -> None:
     just been told to boot answers retryable states until its agent is
     reachable, so both wait rather than failing immediately.
     """
-    from novem.code.compute import NovemComputeError
+    from novem.code.compute import NovemComputeError, NovemComputeTransportError
 
     if kind != "computer":
         print(f"-R and -A are only available for computers, not {kind}s", file=sys.stderr)
@@ -776,14 +784,21 @@ def _computer_session(args: CliArgs, obj: NovemCodeAPI, kind: str) -> None:
 
     computer = cast(Computer, obj)
     argv = args.get("argv")
-    retry = 90.0
+    retry = float(args.get("connect_timeout", 90.0))
+    wait_reported = False
+
+    def on_retry(_: NovemException) -> None:
+        nonlocal wait_reported
+        if not wait_reported:
+            print("novem: waiting for the computer connection...", file=sys.stderr)
+            wait_reported = True
 
     try:
         if args.get("attach"):
             if args.get("run_job") is not None:
                 print("-A and -R cannot be combined; attach or run one command", file=sys.stderr)
                 sys.exit(1)
-            code, signal = computer.shell(retry_seconds=retry)
+            code, signal = computer.shell(retry_seconds=retry, on_retry=on_retry)
         else:
             if not argv:
                 print(
@@ -791,16 +806,36 @@ def _computer_session(args: CliArgs, obj: NovemCodeAPI, kind: str) -> None:
                     file=sys.stderr,
                 )
                 sys.exit(1)
-            stdin = data_on_stdin()
-            code, signal = computer.stream(argv, stdin=stdin, retry_seconds=retry)
+            stdin = stream_on_stdin()
+            code, signal = computer.stream(
+                argv,
+                stdin=stdin,
+                retry_seconds=retry,
+                on_retry=on_retry,
+                forward_signals=True,
+            )
+    except KeyboardInterrupt:
+        print("novem: interrupted", file=sys.stderr)
+        sys.exit(130)
+    except NovemComputeTransportError as e:
+        print(f"novem: {e.cli_message}", file=sys.stderr)
+        # Keep a lost compute session distinct from the command's own status.
+        sys.exit(255)
     except NovemComputeError as e:
         print(f"novem: {e.cli_message}", file=sys.stderr)
         sys.exit(1)
+    except NovemException as e:
+        print(f"novem: {e.cli_message}", file=sys.stderr)
+        sys.exit(255)
 
     # a signalled process has no exit code of its own; report it the way a
     # shell does so callers can branch on it
     if signal:
-        sys.exit(128 + _SIGNAL_NUMBERS.get(signal, 0))
+        signal_number = _SIGNAL_NUMBERS.get(signal)
+        if signal_number is None:
+            print(f"novem: command ended with an unknown signal {signal!r}", file=sys.stderr)
+            sys.exit(255)
+        sys.exit(128 + signal_number)
     sys.exit(code)
 
 

--- a/novem/cli/common.py
+++ b/novem/cli/common.py
@@ -395,21 +395,52 @@ def job(args: CliArgs) -> None:
         is_cli=True,
     )
 
-    # -R (run): trigger job execution, optionally with file attachments
-    if args.get("run_job") is not None and args.get("argv"):
-        print(
-            "-R -- <argv> is not supported for jobs yet; the job runs its "
-            "configured invocation. Drop the -- argv to run it.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
+    # -R (run): trigger job execution. Files are -i/-o; run arguments are
+    # a future release.
     if args.get("run_job") is not None:
-        files = args["run_job"]
+        positional = args["run_job"] or []
+        argv = args.get("argv") or []
+        if positional or argv:
+            if any(a.startswith("@") for a in positional):
+                print(
+                    "-R no longer takes @file uploads — they moved to -i:\n" f"  novem -j {name} -R -i {positional[0]}",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    "-R does not take run arguments yet; the job runs its "
+                    "configured invocation.\n"
+                    "Run arguments are coming in a future release.",
+                    file=sys.stderr,
+                )
+            sys.exit(1)
+
+        inputs = args.get("input_dir") or []
+        outputs = args.get("output_dir") or []
+
+        # @file.ext is one file; a bare path is a directory of files
+        in_files = [i for i in inputs if i.startswith("@")]
+        in_dirs = [i for i in inputs if not i.startswith("@")]
+
+        if len(outputs) > 1:
+            print(
+                "-o can only be given once: a run returns a single output",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        out_dir: Optional[str] = None
+        out_file: Optional[str] = None
+        if outputs:
+            if outputs[0].startswith("@"):
+                out_file = outputs[0][1:]
+            else:
+                out_dir = outputs[0]
+
         j.run(
-            files=files if files else None,
-            input_dir=args.get("input_dir"),
-            output=args.get("output_dir"),
+            files=in_files or None,
+            input_dir=in_dirs or None,
+            output=out_dir,
+            output_file=out_file,
         )
         return
 

--- a/novem/cli/common.py
+++ b/novem/cli/common.py
@@ -396,6 +396,14 @@ def job(args: CliArgs) -> None:
     )
 
     # -R (run): trigger job execution, optionally with file attachments
+    if args.get("run_job") is not None and args.get("argv"):
+        print(
+            "-R -- <argv> is not supported for jobs yet; the job runs its "
+            "configured invocation. Drop the -- argv to run it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     if args.get("run_job") is not None:
         files = args["run_job"]
         j.run(
@@ -629,6 +637,15 @@ def code_resource(args: CliArgs, kind: str) -> None:
         if ptype:
             obj.type = ptype
 
+        # --image REF sets config/image; a bare --image reads it back, the
+        # same way a bare -s lists shares and a bare -t lists tags
+        image_ref = args.get("image_ref")
+        if image_ref is None:
+            print(obj.api_read("/config/image"), end="")
+            return
+        elif image_ref:
+            obj.api_write("/config/image", image_ref)
+
         found_stdin = False
         stdin_data = data_on_stdin()
         stdin_has_data = bool(stdin_data)
@@ -698,11 +715,62 @@ def code_resource(args: CliArgs, kind: str) -> None:
     if tag_op is Tag.CHECK:
         check_membership(kind, name, args, "tags", tag_targets)
 
+    # -R (run) and -A (attach) open a live session on a computer
+    if args.get("run_job") is not None or args.get("attach"):
+        _computer_session(args, obj, kind)
+        return
+
     # -r (read output)
     out = args["out"]
     if out:
         outp = obj.api_read(f"/{out}")
         print(outp, end="")
+
+
+def _computer_session(args: CliArgs, obj: NovemCodeAPI, kind: str) -> None:
+    """Handle -R / -A against a running computer.
+
+    Both are live connections over novem.compute.v1; a computer that has only
+    just been told to boot answers retryable states until its agent is
+    reachable, so both wait rather than failing immediately.
+    """
+    from novem.code.compute import NovemComputeError
+
+    if kind != "computer":
+        print(f"-R and -A are only available for computers, not {kind}s", file=sys.stderr)
+        sys.exit(1)
+
+    computer = cast(Computer, obj)
+    argv = args.get("argv")
+    retry = 90.0
+
+    try:
+        if args.get("attach"):
+            if args.get("run_job") is not None:
+                print("-A and -R cannot be combined; attach or run one command", file=sys.stderr)
+                sys.exit(1)
+            code, signal = computer.shell(retry_seconds=retry)
+        else:
+            if not argv:
+                print(
+                    "-R on a computer needs a command to run, e.g.\n" f"  novem -c {computer.id} -R -- ls -la",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            stdin = data_on_stdin()
+            code, signal = computer.stream(argv, stdin=stdin, retry_seconds=retry)
+    except NovemComputeError as e:
+        print(f"novem: {e.cli_message}", file=sys.stderr)
+        sys.exit(1)
+
+    # a signalled process has no exit code of its own; report it the way a
+    # shell does so callers can branch on it
+    if signal:
+        sys.exit(128 + _SIGNAL_NUMBERS.get(signal, 0))
+    sys.exit(code)
+
+
+_SIGNAL_NUMBERS = {"HUP": 1, "INT": 2, "QUIT": 3, "KILL": 9, "TERM": 15}
 
 
 def space(args: CliArgs) -> None:

--- a/novem/cli/setup.py
+++ b/novem/cli/setup.py
@@ -1,7 +1,7 @@
 import argparse as ap
 import shutil
 from enum import Enum
-from typing import Any, Tuple, cast
+from typing import Any, List, Optional, Tuple, cast
 
 from .args import CliArgs
 
@@ -37,7 +37,12 @@ def formatter(prog: str) -> ap.RawDescriptionHelpFormatter:
 _CODE_SELECTOR_MAP = {
     "-s": "--space",
     "-r": "--repo",
-    "-i": "--image",
+    "-i": "--image-select",
+    # --image is overloaded on the same first-occurrence rule as the shorts:
+    # unclaimed it selects an image, otherwise it sets config/image on the
+    # selected resource. It cannot be its own promotion target, so both
+    # spellings rewrite to the hidden --image-select.
+    "--image": "--image-select",
 }
 
 # Flags that claim the invocation for another resource. When any of these is
@@ -58,7 +63,7 @@ _PRIMARY_SELECTOR_FLAGS = {
     "--space",
     "--repo",
     "--computer",
-    "--image",
+    "--image-select",
 }
 
 # Early-exit commands that historically pair with the legacy meanings of the
@@ -97,6 +102,7 @@ _PROMOTION_NEUTRAL = {
     "--comments",
     "--config",
     "--config-path",
+    "--image",
     "--debug",
     "--dry-run",
     "--dump",
@@ -120,6 +126,28 @@ _PROMOTION_NEUTRAL = {
 
 # Short flags that take a value, for recognising the attached form (-pmyplot).
 _VALUED_SHORT_FLAGS = {"-p", "-g", "-m", "-d", "-j", "-u", "-O", "-G", "-s", "-t", "-r", "-c", "-i", "-o", "-e", "-f"}
+
+
+def split_argv_tail(raw_args: Any) -> Tuple[Any, Optional[List[str]]]:
+    """Split a trailing ``-- argv...`` off the command line.
+
+    ``-R`` runs the selected resource's workload, and everything after a
+    standalone ``--`` is the invocation to run rather than novem flags::
+
+        novem -c box -R -- ls -la
+        novem -j job -R -- python main.py
+
+    The tail is passed through verbatim, so an argument that looks like a
+    flag survives. The CLI has no positional arguments, so a bare ``--``
+    previously meant nothing at all.
+    """
+    if not raw_args:
+        return raw_args, None
+    tokens = list(raw_args)
+    for idx, tok in enumerate(tokens):
+        if tok == "--":
+            return tokens[:idx], tokens[idx + 1 :]
+    return tokens, None
 
 
 def promote_code_selectors(raw_args: Any) -> Any:
@@ -198,21 +226,23 @@ def promote_code_selectors(raw_args: Any) -> Any:
     for idx, tok in enumerate(tokens):
         if tok == "--":
             break
-        base = short_base(tok)
+        if tok.startswith("--"):
+            base, _, attached = tok.partition("=")
+        else:
+            base = short_base(tok)
+            attached = tok[2:] if base != tok else ""
         if base in _CODE_SELECTOR_MAP:
-            if bare_only and not is_bare(idx):
+            if bare_only and (attached or not is_bare(idx)):
                 break
-            if base != tok:
-                # attached value: -smy-space -> --space=my-space
-                tokens[idx] = f"{_CODE_SELECTOR_MAP[base]}={tok[2:]}"
-            else:
-                tokens[idx] = _CODE_SELECTOR_MAP[base]
+            target = _CODE_SELECTOR_MAP[base]
+            tokens[idx] = f"{target}={attached}" if attached else target
             break
 
     return tokens
 
 
 def setup(raw_args: Any = None) -> Tuple[Any, CliArgs]:
+    raw_args, argv_tail = split_argv_tail(raw_args)
     raw_args = promote_code_selectors(raw_args)
 
     parser = ap.ArgumentParser(
@@ -837,13 +867,34 @@ resource is selected they keep their usual meaning:
     )
 
     code.add_argument(
-        "--image",
+        "--image-select",
         dest="image",
         action="store",
         required=False,
         default="",
         nargs="?",
-        help="select image to operate on (also: -i as first selector), no parameter will list all your images",
+        help=ap.SUPPRESS,
+    )
+
+    code.add_argument(
+        "--image",
+        dest="image_ref",
+        action="store",
+        required=False,
+        default="",
+        nargs="?",
+        metavar="REF",
+        help="as the first selector, select an image to operate on (same as -i); "
+        "otherwise set the selected resource's image, e.g. -c my-box --image @novem/base",
+    )
+
+    code.add_argument(
+        "-A",
+        dest="attach",
+        action="store_true",
+        required=False,
+        default=False,
+        help="attach an interactive shell to the selected computer",
     )
 
     invite = parser.add_argument_group("invite")
@@ -983,6 +1034,9 @@ No parameter will list all organisations groups of which you are a member""",
         # None that crashed every consumer.)
         tags = [t.strip() for t in tag.split(",") if t.strip()]
         args["tag"] = (Tag.CHECK, tags)
+
+    # the invocation after `--`, if any (see split_argv_tail)
+    args["argv"] = argv_tail
 
     # everything downstream treats create/delete as booleans
     args["create"] = args["create"] > 0

--- a/novem/cli/setup.py
+++ b/novem/cli/setup.py
@@ -798,28 +798,30 @@ an inline string, @filename to read from a file, or piped via stdin.""",
         dest="run_job",
         nargs="*",
         default=None,
-        metavar="@file",
-        help="run the job, optionally with one or more @file.ext to upload",
+        metavar="ARG",
+        help="run the job. Input and output files are -i and -o; run arguments " "are coming in a future release",
     )
 
     job.add_argument(
         "-i",
         "--input",
         dest="input_dir",
-        action="store",
+        action="append",
         default=None,
-        metavar="dir",
-        help="upload all files in this directory with -R (preserves subdirectories; -R @file wins on name conflict)",
+        metavar="PATH",
+        help="send input with -R. @file.ext sends one file, a bare path sends every "
+        "file in that directory (subdirectories preserved). Repeatable",
     )
 
     job.add_argument(
         "-o",
         "--output",
         dest="output_dir",
-        action="store",
+        action="append",
         default=None,
-        metavar="dir",
-        help="save job output to this directory (created if needed)",
+        metavar="PATH",
+        help="save job output. @file.ext writes it to that file, a bare path writes "
+        "into that directory (created if needed)",
     )
 
     code = parser.add_argument_group(

--- a/novem/cli/setup.py
+++ b/novem/cli/setup.py
@@ -100,6 +100,7 @@ _PROMOTION_NEUTRAL = {
     "--cc",
     "--color",
     "--comments",
+    "--connect-timeout",
     "--config",
     "--config-path",
     "--image",
@@ -146,6 +147,8 @@ def split_argv_tail(raw_args: Any) -> Tuple[Any, Optional[List[str]]]:
     tokens = list(raw_args)
     for idx, tok in enumerate(tokens):
         if tok == "--":
+            if "-R" not in tokens[:idx]:
+                return tokens, None
             return tokens[:idx], tokens[idx + 1 :]
     return tokens, None
 
@@ -897,6 +900,15 @@ resource is selected they keep their usual meaning:
         required=False,
         default=False,
         help="attach an interactive shell to the selected computer",
+    )
+
+    code.add_argument(
+        "--connect-timeout",
+        dest="connect_timeout",
+        type=float,
+        default=90.0,
+        metavar="SECONDS",
+        help="how long -R/-A waits for a computer connection (default: 90)",
     )
 
     invite = parser.add_argument_group("invite")

--- a/novem/cli/setup.py
+++ b/novem/cli/setup.py
@@ -157,7 +157,7 @@ def promote_code_selectors(raw_args: Any) -> Any:
 
         -s  spaces     (legacy: share group)
         -r  repos      (legacy: read path to stdout)
-        -i  images     (legacy: --input upload dir)
+        -i  images     (legacy: --input job input files/dirs)
 
     ``-c`` is not among them: it selects a computer and nothing else, and the
     config file it used to name needs ``--config`` / ``--config-path``. That is

--- a/novem/cli/vis.py
+++ b/novem/cli/vis.py
@@ -1470,6 +1470,7 @@ def list_code_vis(args: CliArgs, kind: str) -> None:
     for p in plist:
         p["_updated"] = _format_relative_time(p.get("updated", ""))
         if kind == "computer":
+            p["name"] = p.get("name") or "-"
             cpu = p.get("cpu")
             p["_cpu"] = f"{cpu:g}" if isinstance(cpu, (int, float)) else (cpu or "-")
             p["_memory"] = p.get("memory") or "-"

--- a/novem/code/__init__.py
+++ b/novem/code/__init__.py
@@ -13,7 +13,7 @@ subclasses set ``_collection``/``_label`` and add their own properties.
 """
 
 import sys
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 
 from novem.exceptions import Novem403, Novem404, raise_on_response
 
@@ -23,6 +23,19 @@ from ..sync import NovemTreeSync
 from ..tags import NovemTags
 from ..utils import cl
 from ..utils import colors as clrs
+from .compute import (
+    ComputeConnection,
+    ExecResult,
+    NovemComputeError,
+    _exec_collect,
+    _exec_stream,
+    _pty_interactive,
+    _run_sync,
+    _split_argv,
+    _with_retry,
+    target_for,
+    ws_url,
+)
 from .space_content import SpaceChange, SpaceContent, SpaceDir, SpaceEntry, SpaceFileInfo, SpacePath, space_changes
 
 
@@ -487,6 +500,8 @@ class Computer(NovemCodeAPI):
     _collection = "computers"
     _label = "computer"
 
+    _compute_owner: Optional[str] = None
+
     def __init__(self, id: str, **kwargs: Any) -> None:
         self.id = id
         super().__init__(**kwargs)
@@ -502,6 +517,107 @@ class Computer(NovemCodeAPI):
     @property
     def info(self) -> str:
         return self.api_read("/info")
+
+    # ── live connections (novem.compute.v1 over /ws-cu) ──────────────────
+
+    def _compute_target(self) -> str:
+        """The canonical target for this computer.
+
+        The owner is always spelled out — the short ``/v1/code/...`` form is
+        not accepted here. Resolved from the token when not scoped to
+        another user, and cached for the object's lifetime.
+        """
+        owner = self.user
+        if not owner:
+            if self._compute_owner is None:
+                self._compute_owner = self.read("whoami").strip()
+            owner = self._compute_owner
+        return target_for(owner, self.id)
+
+    def connect(self) -> "ComputeConnection":
+        """An unopened :class:`ComputeConnection` for this computer's platform.
+
+        For async callers::
+
+            async with computer.connect() as conn:
+                ch = await conn.open_exec(computer.compute_target, "ls")
+        """
+        return ComputeConnection(
+            ws_url(self._api_root),
+            self.token or "",
+            ignore_ssl=bool(getattr(self, "_ignore_ssl", False)),
+            debug=self._debug,
+        )
+
+    @property
+    def compute_target(self) -> str:
+        return self._compute_target()
+
+    def run(
+        self,
+        argv: Union[str, List[str]],
+        mode: str = "argv",
+        cwd: str = "",
+        stdin: Optional[Union[str, bytes]] = None,
+        timeout: int = 600,
+        retry_seconds: float = 0.0,
+    ) -> "ExecResult":
+        """Run one command and return its buffered output and exit status.
+
+        ``argv`` is a list in argv mode (no shell re-parsing) or a command
+        string in shell mode. ``retry_seconds`` retries the open while the
+        computer reports a retryable state, which is what a machine that has
+        only just been told to boot does until its agent is reachable.
+        """
+        command, args = _split_argv(argv, mode)
+        payload = stdin.encode("utf-8") if isinstance(stdin, str) else stdin
+        return _run_sync(
+            _with_retry(
+                lambda conn: _exec_collect(conn, self._compute_target(), command, args, mode, cwd, payload, timeout),
+                self.connect,
+                retry_seconds,
+            )
+        )
+
+    def stream(
+        self,
+        argv: Union[str, List[str]],
+        mode: str = "argv",
+        cwd: str = "",
+        stdin: Optional[Union[str, bytes]] = None,
+        timeout: int = 600,
+        retry_seconds: float = 0.0,
+    ) -> Tuple[int, Optional[str]]:
+        """Run one command, writing its output straight to stdout/stderr.
+
+        Returns ``(code, signal)``; the code is the workload's own, so a
+        non-zero value is a successful call reporting a failed command.
+        """
+        command, args = _split_argv(argv, mode)
+        payload = stdin.encode("utf-8") if isinstance(stdin, str) else stdin
+        return cast(
+            Tuple[int, Optional[str]],
+            _run_sync(
+                _with_retry(
+                    lambda conn: _exec_stream(conn, self._compute_target(), command, args, mode, cwd, payload, timeout),
+                    self.connect,
+                    retry_seconds,
+                )
+            ),
+        )
+
+    def shell(self, retry_seconds: float = 0.0) -> Tuple[int, Optional[str]]:
+        """Attach an interactive shell, taking over the local terminal."""
+        return cast(
+            Tuple[int, Optional[str]],
+            _run_sync(
+                _with_retry(
+                    lambda conn: _pty_interactive(conn, self._compute_target()),
+                    self.connect,
+                    retry_seconds,
+                )
+            ),
+        )
 
 
 class Image(NovemCodeAPI):
@@ -554,4 +670,7 @@ __all__ = [
     "SpaceEntry",
     "SpaceFileInfo",
     "SpaceChange",
+    "ComputeConnection",
+    "ExecResult",
+    "NovemComputeError",
 ]

--- a/novem/code/__init__.py
+++ b/novem/code/__init__.py
@@ -13,9 +13,9 @@ subclasses set ``_collection``/``_label`` and add their own properties.
 """
 
 import sys
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, cast
 
-from novem.exceptions import Novem403, Novem404, raise_on_response
+from novem.exceptions import Novem403, Novem404, NovemException, raise_on_response
 
 from ..api_ref import NovemAPI
 from ..shared import NovemShare
@@ -27,6 +27,8 @@ from .compute import (
     ComputeConnection,
     ExecResult,
     NovemComputeError,
+    NovemComputeTransportError,
+    StdinSource,
     _exec_collect_channel,
     _exec_stream_channel,
     _open_interactive_pty,
@@ -543,8 +545,12 @@ class Computer(NovemCodeAPI):
             async with computer.connect() as conn:
                 ch = await conn.open_exec(computer.compute_target, "ls")
         """
+        try:
+            url = ws_url(self._api_root)
+        except ValueError as e:
+            raise NovemComputeTransportError(str(e)) from e
         return ComputeConnection(
-            ws_url(self._api_root),
+            url,
             self.token or "",
             ignore_ssl=self._config.ignore_ssl,
             debug=self._debug,
@@ -559,19 +565,20 @@ class Computer(NovemCodeAPI):
         argv: Union[str, List[str]],
         mode: str = "argv",
         cwd: str = "",
-        stdin: Optional[Union[str, bytes]] = None,
+        stdin: Optional[StdinSource] = None,
         timeout: int = 600,
         retry_seconds: float = 0.0,
+        on_retry: Optional[Callable[[NovemException], None]] = None,
     ) -> "ExecResult":
         """Run one command and return its buffered output and exit status.
 
         ``argv`` is a list in argv mode (no shell re-parsing) or a command
-        string in shell mode. ``retry_seconds`` retries the open while the
-        computer reports a retryable state, which is what a machine that has
-        only just been told to boot does until its agent is reachable.
+        string in shell mode. ``stdin`` accepts text, bytes, or a readable
+        file-like object; file input is forwarded incrementally while output
+        is collected. ``retry_seconds`` retries the open while the computer
+        reports a retryable state.
         """
         command, args = _split_argv(argv, mode)
-        payload = stdin.encode("utf-8") if isinstance(stdin, str) else stdin
         target = self._compute_target()
         return _run_sync(
             _with_retry(
@@ -583,9 +590,10 @@ class Computer(NovemCodeAPI):
                     cwd=cwd,
                     timeout_seconds=timeout,
                 ),
-                lambda channel: _exec_collect_channel(channel, payload),
+                lambda channel: _exec_collect_channel(channel, stdin),
                 self.connect,
                 retry_seconds,
+                on_retry,
             )
         )
 
@@ -594,17 +602,20 @@ class Computer(NovemCodeAPI):
         argv: Union[str, List[str]],
         mode: str = "argv",
         cwd: str = "",
-        stdin: Optional[Union[str, bytes]] = None,
+        stdin: Optional[StdinSource] = None,
         timeout: int = 600,
         retry_seconds: float = 0.0,
+        on_retry: Optional[Callable[[NovemException], None]] = None,
+        forward_signals: bool = False,
     ) -> Tuple[int, Optional[str]]:
         """Run one command, writing its output straight to stdout/stderr.
 
-        Returns ``(code, signal)``; the code is the workload's own, so a
-        non-zero value is a successful call reporting a failed command.
+        ``stdin`` accepts text, bytes, or a readable file-like object. File
+        input and command output are handled concurrently. Returns ``(code,
+        signal)``; the code is the workload's own, so a non-zero value is a
+        successful call reporting a failed command.
         """
         command, args = _split_argv(argv, mode)
-        payload = stdin.encode("utf-8") if isinstance(stdin, str) else stdin
         target = self._compute_target()
         return cast(
             Tuple[int, Optional[str]],
@@ -618,14 +629,19 @@ class Computer(NovemCodeAPI):
                         cwd=cwd,
                         timeout_seconds=timeout,
                     ),
-                    lambda channel: _exec_stream_channel(channel, payload),
+                    lambda channel: _exec_stream_channel(channel, stdin, forward_signals=forward_signals),
                     self.connect,
                     retry_seconds,
+                    on_retry,
                 )
             ),
         )
 
-    def shell(self, retry_seconds: float = 0.0) -> Tuple[int, Optional[str]]:
+    def shell(
+        self,
+        retry_seconds: float = 0.0,
+        on_retry: Optional[Callable[[NovemException], None]] = None,
+    ) -> Tuple[int, Optional[str]]:
         """Attach an interactive shell, taking over the local terminal."""
         target = self._compute_target()
         return cast(
@@ -636,6 +652,7 @@ class Computer(NovemCodeAPI):
                     _pty_interactive,
                     self.connect,
                     retry_seconds,
+                    on_retry,
                 )
             ),
         )
@@ -694,4 +711,5 @@ __all__ = [
     "ComputeConnection",
     "ExecResult",
     "NovemComputeError",
+    "NovemComputeTransportError",
 ]

--- a/novem/code/__init__.py
+++ b/novem/code/__init__.py
@@ -27,8 +27,9 @@ from .compute import (
     ComputeConnection,
     ExecResult,
     NovemComputeError,
-    _exec_collect,
-    _exec_stream,
+    _exec_collect_channel,
+    _exec_stream_channel,
+    _open_interactive_pty,
     _pty_interactive,
     _run_sync,
     _split_argv,
@@ -545,7 +546,7 @@ class Computer(NovemCodeAPI):
         return ComputeConnection(
             ws_url(self._api_root),
             self.token or "",
-            ignore_ssl=bool(getattr(self, "_ignore_ssl", False)),
+            ignore_ssl=self._config.ignore_ssl,
             debug=self._debug,
         )
 
@@ -571,9 +572,18 @@ class Computer(NovemCodeAPI):
         """
         command, args = _split_argv(argv, mode)
         payload = stdin.encode("utf-8") if isinstance(stdin, str) else stdin
+        target = self._compute_target()
         return _run_sync(
             _with_retry(
-                lambda conn: _exec_collect(conn, self._compute_target(), command, args, mode, cwd, payload, timeout),
+                lambda conn: conn.open_exec(
+                    target,
+                    command,
+                    args,
+                    mode=mode,
+                    cwd=cwd,
+                    timeout_seconds=timeout,
+                ),
+                lambda channel: _exec_collect_channel(channel, payload),
                 self.connect,
                 retry_seconds,
             )
@@ -595,11 +605,20 @@ class Computer(NovemCodeAPI):
         """
         command, args = _split_argv(argv, mode)
         payload = stdin.encode("utf-8") if isinstance(stdin, str) else stdin
+        target = self._compute_target()
         return cast(
             Tuple[int, Optional[str]],
             _run_sync(
                 _with_retry(
-                    lambda conn: _exec_stream(conn, self._compute_target(), command, args, mode, cwd, payload, timeout),
+                    lambda conn: conn.open_exec(
+                        target,
+                        command,
+                        args,
+                        mode=mode,
+                        cwd=cwd,
+                        timeout_seconds=timeout,
+                    ),
+                    lambda channel: _exec_stream_channel(channel, payload),
                     self.connect,
                     retry_seconds,
                 )
@@ -608,11 +627,13 @@ class Computer(NovemCodeAPI):
 
     def shell(self, retry_seconds: float = 0.0) -> Tuple[int, Optional[str]]:
         """Attach an interactive shell, taking over the local terminal."""
+        target = self._compute_target()
         return cast(
             Tuple[int, Optional[str]],
             _run_sync(
                 _with_retry(
-                    lambda conn: _pty_interactive(conn, self._compute_target()),
+                    lambda conn: _open_interactive_pty(conn, target),
+                    _pty_interactive,
                     self.connect,
                     retry_seconds,
                 )

--- a/novem/code/compute.py
+++ b/novem/code/compute.py
@@ -1,0 +1,682 @@
+"""Live connections to a running novem computer.
+
+A computer exposes one multiplexed WebSocket — ``novem.compute.v1`` on
+``/ws-cu`` — carrying independent channels. This module implements the
+client side of that protocol:
+
+    c = Computer("box")
+
+    # one-off command, buffered
+    res = c.run(["ls", "-la"], cwd="/home/user")
+    print(res.stdout, res.code)
+
+    # streamed, as it arrives
+    for stream, data in c.stream(["tail", "-f", "/var/log/app.log"]):
+        ...
+
+    # interactive shell (takes over the terminal)
+    c.shell()
+
+The protocol is transcribed from the server's own schemas: text messages are
+strict JSON (unknown fields are rejected by the server), and byte data uses a
+single binary layout::
+
+    byte 0       stream discriminator (0 pty/tcp + all client input,
+                                       1 exec stdout, 2 exec stderr)
+    bytes 1..16  raw 128-bit channel id
+    bytes 17..   payload, 1..65536 bytes
+
+Channels are opened with a caller-generated ``request_id`` and answered with
+``ready`` (carrying an opaque channel id) or a scoped ``error``. A denied open
+leaves sibling channels usable; a protocol violation closes the connection.
+"""
+
+import asyncio
+import base64
+import json
+import os
+import secrets
+import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple
+from urllib.parse import urlparse
+
+from novem.exceptions import NovemException
+
+if TYPE_CHECKING:  # pragma: no cover
+    from . import Computer
+
+PROTOCOL = "novem.compute.v1"
+PATH = "/ws-cu"
+MAX_DATA_BYTES = 64 * 1024
+BINARY_HEADER = 17
+
+# stream discriminators
+STREAM_DATA = 0  # pty/tcp bytes, and every client-to-server frame
+STREAM_STDOUT = 1
+STREAM_STDERR = 2
+
+# The server's stable error vocabulary. Anything outside this set is a
+# protocol violation on the server's side, not ours.
+ERROR_CODES = frozenset(
+    {
+        "invalid_request",
+        "not_found",
+        "not_running",
+        "limit_exceeded",
+        "agent_upgrade_required",
+        "authorization_revoked",
+        "computer_restarted",
+        "timeout",
+        "backpressure_timeout",
+        "upstream_unavailable",
+        "process_start_failed",
+        "connection_failed",
+        "protocol_error",
+    }
+)
+
+# Codes worth retrying against the same target: a computer that has just been
+# told to boot answers these until its agent is reachable.
+RETRYABLE_CODES = frozenset({"not_running", "upstream_unavailable", "timeout"})
+
+SIGNALS = frozenset({"HUP", "INT", "QUIT", "TERM", "KILL"})
+
+
+class NovemComputeError(NovemException):
+    """A scoped error from the compute protocol.
+
+    ``code`` is one of the server's stable codes; messages are sanitised
+    server-side and never carry run ids, addresses or command payloads.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+    @property
+    def retryable(self) -> bool:
+        return self.code in RETRYABLE_CODES
+
+    @property
+    def cli_message(self) -> str:
+        hint = _HINTS.get(self.code)
+        base = self.message or self.code
+        return f"{base}\n{hint}" if hint else base
+
+
+_HINTS = {
+    # A missing entitlement, no access, and no such computer are
+    # deliberately indistinguishable — never claim "permission denied".
+    "not_found": "The computer was not found, or you do not have access to it.",
+    "not_running": "The computer is not running. Start it with: novem -c <name> -w status online",
+    "agent_upgrade_required": "The computer is running an older agent. Restart it to pick up the new one.",
+    "limit_exceeded": "Too many open connections or channels. Close one and try again.",
+    "upstream_unavailable": "The compute service is temporarily unavailable.",
+}
+
+
+@dataclass
+class Hello:
+    """The server's opening message, carrying negotiated limits."""
+
+    protocol: str
+    max_channels: int
+    max_data_bytes: int
+    heartbeat_seconds: int
+
+
+@dataclass
+class ExecResult:
+    """The outcome of a buffered :meth:`Computer.run`."""
+
+    code: int
+    signal: Optional[str]
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool:
+        return self.code == 0 and self.signal is None
+
+
+def _channel_bytes(channel: str) -> bytes:
+    """22-char unpadded base64url -> the raw 16 bytes."""
+    return base64.urlsafe_b64decode(channel + "==")
+
+
+def _channel_str(raw: bytes) -> str:
+    """The raw 16 bytes -> 22-char unpadded base64url."""
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def encode_frame(channel: str, payload: bytes, stream: int = STREAM_DATA) -> bytes:
+    if not payload:
+        raise ValueError("empty data frames are invalid")
+    if len(payload) > MAX_DATA_BYTES:
+        raise ValueError(f"payload exceeds {MAX_DATA_BYTES} bytes")
+    return bytes([stream]) + _channel_bytes(channel) + payload
+
+
+def decode_frame(data: bytes) -> Tuple[int, str, bytes]:
+    if len(data) <= BINARY_HEADER:
+        raise ValueError("binary frame is too short")
+    return data[0], _channel_str(data[1:BINARY_HEADER]), data[BINARY_HEADER:]
+
+
+def ws_url(api_root: str) -> str:
+    """Derive the compute endpoint from the configured api root.
+
+    ``/ws-cu`` is served at the host root rather than under ``/v1``, and the
+    path must match exactly — no trailing slash, query or fragment.
+    """
+    parsed = urlparse(api_root)
+    scheme = "wss" if parsed.scheme in ("https", "wss") else "ws"
+    netloc = parsed.netloc or parsed.path
+    return f"{scheme}://{netloc}{PATH}"
+
+
+def target_for(owner: str, computer: str) -> str:
+    """The canonical target: the owner is always spelled out.
+
+    The short ``/v1/code/computers/<name>`` form is not accepted here.
+    """
+    return f"/v1/users/{owner}/code/computers/{computer}"
+
+
+class Channel:
+    """One open channel on a :class:`ComputeConnection`."""
+
+    def __init__(self, conn: "ComputeConnection", channel: str, kind: str) -> None:
+        self._conn = conn
+        self.id = channel
+        self.kind = kind
+        self._queue: "asyncio.Queue[Optional[Tuple[int, bytes]]]" = asyncio.Queue()
+        self._exit: "asyncio.Future[Tuple[int, Optional[str]]]" = asyncio.get_event_loop().create_future()
+        self._closed = False
+
+    # -- inbound, driven by the connection's read loop ---------------------
+
+    def _feed(self, stream: int, data: bytes) -> None:
+        self._queue.put_nowait((stream, data))
+
+    def _finish(self, code: int, signal: Optional[str]) -> None:
+        if not self._exit.done():
+            self._exit.set_result((code, signal))
+        self._queue.put_nowait(None)
+
+    def _fail(self, err: NovemComputeError) -> None:
+        if not self._exit.done():
+            self._exit.set_exception(err)
+        self._queue.put_nowait(None)
+
+    def _closed_by_server(self) -> None:
+        self._closed = True
+        if not self._exit.done():
+            self._exit.set_result((0, None))
+        self._queue.put_nowait(None)
+
+    # -- outbound ----------------------------------------------------------
+
+    async def send(self, payload: bytes) -> None:
+        """Write bytes to the channel's stdin (or the TCP stream)."""
+        for i in range(0, len(payload), MAX_DATA_BYTES):
+            await self._conn._send_binary(encode_frame(self.id, payload[i : i + MAX_DATA_BYTES]))
+
+    async def stdin_eof(self) -> None:
+        """Close stdin without closing the channel.
+
+        On a PTY this writes Ctrl-D rather than closing the master, and
+        sending it twice is a protocol violation.
+        """
+        await self._conn._send_json({"type": "stdin_eof", "channel": self.id})
+
+    async def resize(self, rows: int, cols: int) -> None:
+        if self.kind != "pty":
+            raise ValueError("resize is only valid on a pty channel")
+        await self._conn._send_json({"type": "resize", "channel": self.id, "rows": rows, "cols": cols})
+
+    async def signal(self, name: str) -> None:
+        if name not in SIGNALS:
+            raise ValueError(f"signal must be one of {sorted(SIGNALS)}")
+        await self._conn._send_json({"type": "signal", "channel": self.id, "signal": name})
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._conn._send_json({"type": "close", "channel": self.id})
+
+    # -- consumption -------------------------------------------------------
+
+    async def __aiter__(self) -> AsyncIterator[Tuple[int, bytes]]:
+        while True:
+            item = await self._queue.get()
+            if item is None:
+                return
+            yield item
+
+    async def wait(self) -> Tuple[int, Optional[str]]:
+        """Await termination, returning ``(code, signal)``.
+
+        The wire carries the exit code as a signed 32-bit value: a process
+        killed by a signal reports ``-1`` with a non-null signal name.
+        """
+        return await self._exit
+
+
+class ComputeConnection:
+    """A live ``novem.compute.v1`` connection.
+
+    Use as an async context manager; channels opened on it are multiplexed
+    over the single socket.
+    """
+
+    def __init__(self, url: str, token: str, ignore_ssl: bool = False, debug: bool = False) -> None:
+        self._url = url
+        self._token = token
+        self._ignore_ssl = ignore_ssl
+        self._debug = debug
+        self._ws: Any = None
+        self._session: Any = None
+        self._reader: Optional["asyncio.Task[None]"] = None
+        self.hello: Optional[Hello] = None
+        self._channels: Dict[str, Channel] = {}
+        self._pending: Dict[str, "asyncio.Future[Channel]"] = {}
+        self._fatal: Optional[BaseException] = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    @staticmethod
+    def _aiohttp() -> Any:
+        try:
+            import aiohttp
+        except ImportError:
+            raise ImportError('The "compute" extra is required. Install with: pip install novem[compute]')
+        return aiohttp
+
+    async def __aenter__(self) -> "ComputeConnection":
+        aiohttp = self._aiohttp()
+
+        if not self._token:
+            raise NovemException("No authentication token found. Run novem --init first.")
+
+        # A native client must not send Origin: it is self-asserted and
+        # therefore neither required nor trusted by the server.
+        self._session = aiohttp.ClientSession()
+        try:
+            self._ws = await self._session.ws_connect(
+                self._url,
+                protocols=(PROTOCOL,),
+                headers={"Authorization": f"Bearer {self._token}"},
+                max_msg_size=128 * 1024,
+                ssl=False if self._ignore_ssl else True,
+                autoping=True,
+            )
+        except Exception:
+            await self._session.close()
+            raise
+
+        if self._debug:
+            print(f"WS: {self._url} ({PROTOCOL})", file=sys.stderr)
+
+        self._reader = asyncio.ensure_future(self._read_loop())
+        await self._await_hello()
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        if self._reader:
+            self._reader.cancel()
+            try:
+                await self._reader
+            except (asyncio.CancelledError, Exception):
+                pass
+        if self._ws is not None:
+            await self._ws.close()
+        if self._session is not None:
+            await self._session.close()
+
+    async def _await_hello(self) -> None:
+        # Clients must wait for and validate hello before opening channels.
+        for _ in range(200):
+            if self.hello is not None:
+                return
+            if self._fatal is not None:
+                raise self._fatal
+            await asyncio.sleep(0.01)
+        raise NovemException("compute connection did not send hello")
+
+    # -- plumbing ----------------------------------------------------------
+
+    async def _send_json(self, message: Dict[str, Any]) -> None:
+        if self._fatal is not None:
+            raise self._fatal
+        await self._ws.send_str(json.dumps(message))
+
+    async def _send_binary(self, frame: bytes) -> None:
+        if self._fatal is not None:
+            raise self._fatal
+        await self._ws.send_bytes(frame)
+
+    async def _read_loop(self) -> None:
+        aiohttp = self._aiohttp()
+        try:
+            async for msg in self._ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    self._on_text(json.loads(msg.data))
+                elif msg.type == aiohttp.WSMsgType.BINARY:
+                    stream, channel, payload = decode_frame(msg.data)
+                    ch = self._channels.get(channel)
+                    if ch is not None:
+                        ch._feed(stream, payload)
+                elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # pragma: no cover - transport failure
+            self._abort(e)
+            return
+        self._abort(NovemException("compute connection closed"))
+
+    def _abort(self, err: BaseException) -> None:
+        self._fatal = err
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.set_exception(err)
+        self._pending.clear()
+        for ch in list(self._channels.values()):
+            if not ch._exit.done():
+                ch._exit.set_exception(err)
+            ch._queue.put_nowait(None)
+
+    def _on_text(self, msg: Dict[str, Any]) -> None:
+        kind = msg.get("type")
+
+        if kind == "hello":
+            self.hello = Hello(
+                protocol=msg.get("protocol", ""),
+                max_channels=int(msg.get("max_channels", 0)),
+                max_data_bytes=int(msg.get("max_data_bytes", 0)),
+                heartbeat_seconds=int(msg.get("heartbeat_seconds", 0)),
+            )
+            if self.hello.protocol != PROTOCOL:
+                self._abort(NovemException(f"unexpected compute protocol {self.hello.protocol!r}"))
+            return
+
+        if kind == "ready":
+            fut = self._pending.pop(msg.get("request_id", ""), None)
+            channel = Channel(self, msg["channel"], msg.get("kind", ""))
+            self._channels[channel.id] = channel
+            if fut is not None and not fut.done():
+                fut.set_result(channel)
+            return
+
+        if kind == "error":
+            code = msg.get("code", "protocol_error")
+            err = NovemComputeError(code, msg.get("message", code))
+            # before ready the error carries request_id, after it a channel
+            rid = msg.get("request_id")
+            if rid is not None:
+                fut = self._pending.pop(rid, None)
+                if fut is not None and not fut.done():
+                    fut.set_exception(err)
+                return
+            ch = self._channels.get(msg.get("channel", ""))
+            if ch is not None:
+                ch._fail(err)
+            return
+
+        if kind == "exit":
+            ch = self._channels.get(msg.get("channel", ""))
+            if ch is not None:
+                ch._finish(int(msg.get("code", 0)), msg.get("signal"))
+            return
+
+        if kind == "closed":
+            ch = self._channels.get(msg.get("channel", ""))
+            if ch is not None:
+                ch._closed_by_server()
+            return
+
+    # -- opening channels --------------------------------------------------
+
+    async def _open(self, spec: Dict[str, Any]) -> Channel:
+        request_id = spec["request_id"]
+        fut: "asyncio.Future[Channel]" = asyncio.get_event_loop().create_future()
+        self._pending[request_id] = fut
+        await self._send_json(spec)
+        return await fut
+
+    async def open_exec(
+        self,
+        target: str,
+        command: str,
+        args: Optional[List[str]] = None,
+        mode: str = "argv",
+        cwd: str = "",
+        timeout_seconds: int = 600,
+    ) -> Channel:
+        if mode not in ("argv", "shell"):
+            raise ValueError('mode must be "argv" or "shell"')
+        if mode == "shell" and args:
+            raise ValueError("shell mode does not accept args")
+        if mode == "argv" and "/" in command and not command.startswith("/"):
+            raise ValueError("a relative executable path is invalid; use an absolute path")
+        if cwd and not cwd.startswith("/"):
+            raise ValueError("cwd must be absolute")
+        return await self._open(
+            {
+                "type": "open",
+                "request_id": _request_id(),
+                "target": target,
+                "kind": "exec",
+                "mode": mode,
+                "command": command,
+                "args": list(args or []),
+                "cwd": cwd,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+
+    async def open_pty(
+        self,
+        target: str,
+        rows: int = 24,
+        cols: int = 80,
+        timeout_seconds: int = 28800,
+    ) -> Channel:
+        return await self._open(
+            {
+                "type": "open",
+                "request_id": _request_id(),
+                "target": target,
+                "kind": "pty",
+                "rows": max(1, min(1000, rows)),
+                "cols": max(1, min(1000, cols)),
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+
+
+def _request_id() -> str:
+    return f"np-{secrets.token_hex(8)}"
+
+
+# ── sync helpers used by the CLI and by simple library callers ────────────
+
+
+def _run_sync(coro: Any) -> Any:
+    """Drive a coroutine from synchronous code."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    coro.close()
+    raise NovemException(
+        "A compute call was made from inside a running event loop. "
+        "Use the async API (Computer.connect()) instead."
+    )
+
+
+def _split_argv(argv: Any, mode: str) -> Tuple[str, List[str]]:
+    """Split a caller's invocation into ``(command, args)``.
+
+    In argv mode a list is taken apart so arguments survive without shell
+    re-parsing; in shell mode the command is one string and args are refused.
+    """
+    if mode == "shell":
+        if not isinstance(argv, str):
+            raise ValueError("shell mode takes a single command string")
+        return argv, []
+    if isinstance(argv, str):
+        return argv, []
+    if not argv:
+        raise ValueError("a command is required")
+    return argv[0], list(argv[1:])
+
+
+async def _with_retry(op: Any, connect: Any, retry_seconds: float) -> Any:
+    """Run ``op`` against a fresh connection, retrying retryable states.
+
+    A computer that has just been told to boot reports ``not_running`` (and
+    friends) until its agent is reachable, so a bounded retry turns the boot
+    race into a wait rather than a failure.
+    """
+    import time
+
+    deadline = time.monotonic() + max(0.0, retry_seconds)
+    delay = 0.5
+    while True:
+        try:
+            async with connect() as conn:
+                return await op(conn)
+        except NovemComputeError as e:
+            if not e.retryable or time.monotonic() >= deadline:
+                raise
+        await asyncio.sleep(delay)
+        delay = min(delay * 1.5, 3.0)
+
+
+async def _exec_collect(
+    conn: ComputeConnection,
+    target: str,
+    command: str,
+    args: List[str],
+    mode: str,
+    cwd: str,
+    stdin: Optional[bytes],
+    timeout_seconds: int,
+) -> ExecResult:
+    ch = await conn.open_exec(target, command, args, mode=mode, cwd=cwd, timeout_seconds=timeout_seconds)
+    if stdin:
+        await ch.send(stdin)
+    await ch.stdin_eof()
+
+    out: List[bytes] = []
+    err: List[bytes] = []
+    async for stream, data in ch:
+        (err if stream == STREAM_STDERR else out).append(data)
+    code, signal = await ch.wait()
+    return ExecResult(
+        code=code,
+        signal=signal,
+        stdout=b"".join(out).decode("utf-8", "replace"),
+        stderr=b"".join(err).decode("utf-8", "replace"),
+    )
+
+
+async def _exec_stream(
+    conn: ComputeConnection,
+    target: str,
+    command: str,
+    args: List[str],
+    mode: str,
+    cwd: str,
+    stdin: Optional[bytes],
+    timeout_seconds: int,
+) -> Tuple[int, Optional[str]]:
+    """Stream straight to local stdout/stderr and return the exit status."""
+    ch = await conn.open_exec(target, command, args, mode=mode, cwd=cwd, timeout_seconds=timeout_seconds)
+    if stdin:
+        await ch.send(stdin)
+    await ch.stdin_eof()
+
+    async for stream, data in ch:
+        sink = sys.stderr.buffer if stream == STREAM_STDERR else sys.stdout.buffer
+        sink.write(data)
+        sink.flush()
+    return await ch.wait()
+
+
+async def _pty_interactive(conn: ComputeConnection, target: str) -> Tuple[int, Optional[str]]:
+    """Attach the local terminal to a PTY channel."""
+    if os.name == "nt":  # pragma: no cover - platform guard
+        raise NovemException("An interactive shell is not supported on Windows yet.")
+
+    import signal as signalmod
+    import termios
+    import tty
+
+    if not sys.stdin.isatty():
+        raise NovemException("An interactive shell requires a terminal. Use -R to run a command instead.")
+
+    size = os.get_terminal_size()
+    ch = await conn.open_pty(target, rows=size.lines, cols=size.columns)
+
+    loop = asyncio.get_event_loop()
+    fd = sys.stdin.fileno()
+    saved = termios.tcgetattr(fd)
+
+    def on_winch(*_: Any) -> None:
+        try:
+            new = os.get_terminal_size()
+        except OSError:
+            return
+        asyncio.ensure_future(ch.resize(new.lines, new.columns))
+
+    def on_stdin() -> None:
+        data = os.read(fd, 8192)
+        if data:
+            asyncio.ensure_future(ch.send(data))
+
+    try:
+        tty.setraw(fd)
+        loop.add_signal_handler(signalmod.SIGWINCH, on_winch)
+        loop.add_reader(fd, on_stdin)
+
+        async for _stream, data in ch:
+            sys.stdout.buffer.write(data)
+            sys.stdout.buffer.flush()
+        return await ch.wait()
+    finally:
+        loop.remove_reader(fd)
+        try:
+            loop.remove_signal_handler(signalmod.SIGWINCH)
+        except (NotImplementedError, RuntimeError):  # pragma: no cover
+            pass
+        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+
+
+__all__ = [
+    "PROTOCOL",
+    "PATH",
+    "MAX_DATA_BYTES",
+    "STREAM_DATA",
+    "STREAM_STDOUT",
+    "STREAM_STDERR",
+    "ERROR_CODES",
+    "RETRYABLE_CODES",
+    "NovemComputeError",
+    "Hello",
+    "ExecResult",
+    "Channel",
+    "ComputeConnection",
+    "encode_frame",
+    "decode_frame",
+    "ws_url",
+    "target_for",
+]

--- a/novem/code/compute.py
+++ b/novem/code/compute.py
@@ -117,12 +117,26 @@ class NovemComputeTransportError(NovemException):
         *,
         code: str = "connection_failed",
         retryable: bool = False,
+        retry_after: Optional[float] = None,
     ) -> None:
         self.close_code = close_code
         self.code = code
         self.retryable = retryable
+        self.retry_after = retry_after
         detail = f"{message} (WebSocket close code {close_code})" if close_code is not None else message
         super().__init__(detail)
+
+    @property
+    def cli_message(self) -> str:
+        base = str(self)
+        hint = _HINTS.get(self.code)
+        if not hint:
+            return base
+        base_key = base.casefold().strip().rstrip(".")
+        hint_key = hint.casefold().strip().rstrip(".")
+        if hint_key in base_key or base_key in hint_key:
+            return base
+        return f"{base}\n{hint}"
 
 
 _HINTS = {
@@ -149,6 +163,30 @@ _CLOSE_REASONS = {
     1008: ("protocol_error", "The compute protocol was rejected. Upgrade the CLI and try again."),
     1011: ("upstream_unavailable", "The compute service ended the session."),
 }
+
+
+def _retry_after_seconds(value: Optional[str]) -> Optional[float]:
+    """Parse an HTTP Retry-After delay or date into seconds from now."""
+
+    if not value:
+        return None
+    value = value.strip()
+    try:
+        seconds = int(value)
+    except ValueError:
+        from datetime import datetime, timezone
+        from email.utils import parsedate_to_datetime
+
+        try:
+            when = parsedate_to_datetime(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if when is None:
+            return None
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=timezone.utc)
+        return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
+    return float(seconds) if seconds >= 0 else None
 
 
 @dataclass
@@ -374,17 +412,21 @@ class ComputeConnection:
             raise
         except aiohttp.WSServerHandshakeError as e:
             await self.aclose()
+            headers = getattr(e, "headers", None)
+            retry_after = _retry_after_seconds(headers.get("Retry-After") if headers is not None else None)
             if e.status == 429:
                 raise NovemComputeTransportError(
                     "compute connection is temporarily at capacity",
                     code="limit_exceeded",
                     retryable=True,
+                    retry_after=retry_after,
                 ) from e
             if e.status == 503:
                 raise NovemComputeTransportError(
                     "compute service is temporarily unavailable",
                     code="upstream_unavailable",
                     retryable=True,
+                    retry_after=retry_after,
                 ) from e
             raise NovemComputeTransportError(f"compute connection could not be established (HTTP {e.status})") from e
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
@@ -715,6 +757,21 @@ async def _with_retry(
             on_retry(error)
         notified = True
 
+    async def wait_before_retry(error: NovemException) -> bool:
+        """Wait for local backoff and any longer server-requested delay."""
+
+        nonlocal delay
+        remaining = max(0.0, deadline - time.monotonic())
+        retry_after = getattr(error, "retry_after", None)
+        wait = max(delay, retry_after or 0.0)
+        if retry_after is not None and retry_after > remaining:
+            if remaining:
+                await asyncio.sleep(remaining)
+            return False
+        await asyncio.sleep(min(wait, remaining))
+        delay = min(delay * 1.5, 3.0)
+        return True
+
     # Retrying a failed upgrade is safe because no open request was sent. Once
     # connected, explicit admission errors reuse that connection; a transport
     # failure after an open request is never replayed because readiness may
@@ -727,8 +784,8 @@ async def _with_retry(
             if not e.retryable or time.monotonic() >= deadline:
                 raise
             notify(e)
-            await asyncio.sleep(min(delay, max(0.0, deadline - time.monotonic())))
-            delay = min(delay * 1.5, 3.0)
+            if not await wait_before_retry(e):
+                raise
             continue
         break
 
@@ -740,10 +797,10 @@ async def _with_retry(
                 if not e.retryable or time.monotonic() >= deadline:
                     raise
                 notify(e)
+                if not await wait_before_retry(e):
+                    raise
             else:
                 return await use_channel(channel)
-            await asyncio.sleep(min(delay, max(0.0, deadline - time.monotonic())))
-            delay = min(delay * 1.5, 3.0)
     finally:
         await context.__aexit__(*sys.exc_info())
 
@@ -986,7 +1043,10 @@ async def _pty_interactive(ch: Channel) -> Tuple[int, Optional[str]]:
 
     loop = asyncio.get_event_loop()
     fd = sys.stdin.fileno()
-    saved = termios.tcgetattr(fd)
+    try:
+        saved = termios.tcgetattr(fd)
+    except (OSError, termios.error) as e:
+        raise NovemException("The local terminal became unavailable before the interactive shell was ready.") from e
     outbound: "asyncio.Queue[Tuple[str, Any]]" = asyncio.Queue()
     reader_registered = False
     stdin_ended = False
@@ -1038,7 +1098,10 @@ async def _pty_interactive(ch: Channel) -> Tuple[int, Optional[str]]:
         return await ch.wait()
 
     try:
-        tty.setraw(fd)
+        try:
+            tty.setraw(fd)
+        except (OSError, termios.error) as e:
+            raise NovemException("The local terminal became unavailable before the interactive shell was ready.") from e
         loop.add_signal_handler(signalmod.SIGWINCH, on_winch)
         register_reader()
 

--- a/novem/code/compute.py
+++ b/novem/code/compute.py
@@ -10,16 +10,14 @@ client side of that protocol:
     res = c.run(["ls", "-la"], cwd="/home/user")
     print(res.stdout, res.code)
 
-    # streamed, as it arrives
-    for stream, data in c.stream(["tail", "-f", "/var/log/app.log"]):
-        ...
+    # streamed straight to local stdout/stderr
+    code, signal = c.stream(["tail", "-f", "/var/log/app.log"])
 
     # interactive shell (takes over the terminal)
     c.shell()
 
-The protocol is transcribed from the server's own schemas: text messages are
-strict JSON (unknown fields are rejected by the server), and byte data uses a
-single binary layout::
+Text control messages are strict JSON, and byte data uses a single binary
+layout::
 
     byte 0       stream discriminator (0 pty/tcp + all client input,
                                        1 exec stdout, 2 exec stderr)
@@ -290,7 +288,7 @@ class ComputeConnection:
         try:
             import aiohttp
         except ImportError:
-            raise ImportError('The "compute" extra is required. Install with: pip install novem[compute]')
+            raise ImportError("The compute extra is required. Install with: pip install 'novem[compute]'") from None
         return aiohttp
 
     async def __aenter__(self) -> "ComputeConnection":
@@ -535,39 +533,34 @@ def _split_argv(argv: Any, mode: str) -> Tuple[str, List[str]]:
     return argv[0], list(argv[1:])
 
 
-async def _with_retry(op: Any, connect: Any, retry_seconds: float) -> Any:
-    """Run ``op`` against a fresh connection, retrying retryable states.
+async def _with_retry(open_channel: Any, use_channel: Any, connect: Any, retry_seconds: float) -> Any:
+    """Open and use a channel, retrying only failed admission attempts.
 
     A computer that has just been told to boot reports ``not_running`` (and
     friends) until its agent is reachable, so a bounded retry turns the boot
-    race into a wait rather than a failure.
+    race into a wait rather than a failure. Once a channel is ready,
+    ``use_channel`` runs outside the retry handler so an interrupted command is
+    never replayed.
     """
     import time
 
     deadline = time.monotonic() + max(0.0, retry_seconds)
     delay = 0.5
     while True:
-        try:
-            async with connect() as conn:
-                return await op(conn)
-        except NovemComputeError as e:
-            if not e.retryable or time.monotonic() >= deadline:
-                raise
+        async with connect() as conn:
+            try:
+                channel = await open_channel(conn)
+            except NovemComputeError as e:
+                if not e.retryable or time.monotonic() >= deadline:
+                    raise
+            else:
+                return await use_channel(channel)
         await asyncio.sleep(delay)
         delay = min(delay * 1.5, 3.0)
 
 
-async def _exec_collect(
-    conn: ComputeConnection,
-    target: str,
-    command: str,
-    args: List[str],
-    mode: str,
-    cwd: str,
-    stdin: Optional[bytes],
-    timeout_seconds: int,
-) -> ExecResult:
-    ch = await conn.open_exec(target, command, args, mode=mode, cwd=cwd, timeout_seconds=timeout_seconds)
+async def _exec_collect_channel(ch: Channel, stdin: Optional[bytes]) -> ExecResult:
+    """Collect output from an admitted exec channel."""
     if stdin:
         await ch.send(stdin)
     await ch.stdin_eof()
@@ -585,6 +578,33 @@ async def _exec_collect(
     )
 
 
+async def _exec_collect(
+    conn: ComputeConnection,
+    target: str,
+    command: str,
+    args: List[str],
+    mode: str,
+    cwd: str,
+    stdin: Optional[bytes],
+    timeout_seconds: int,
+) -> ExecResult:
+    ch = await conn.open_exec(target, command, args, mode=mode, cwd=cwd, timeout_seconds=timeout_seconds)
+    return await _exec_collect_channel(ch, stdin)
+
+
+async def _exec_stream_channel(ch: Channel, stdin: Optional[bytes]) -> Tuple[int, Optional[str]]:
+    """Stream output from an admitted exec channel to local stdout/stderr."""
+    if stdin:
+        await ch.send(stdin)
+    await ch.stdin_eof()
+
+    async for stream, data in ch:
+        sink = sys.stderr.buffer if stream == STREAM_STDERR else sys.stdout.buffer
+        sink.write(data)
+        sink.flush()
+    return await ch.wait()
+
+
 async def _exec_stream(
     conn: ComputeConnection,
     target: str,
@@ -597,31 +617,25 @@ async def _exec_stream(
 ) -> Tuple[int, Optional[str]]:
     """Stream straight to local stdout/stderr and return the exit status."""
     ch = await conn.open_exec(target, command, args, mode=mode, cwd=cwd, timeout_seconds=timeout_seconds)
-    if stdin:
-        await ch.send(stdin)
-    await ch.stdin_eof()
-
-    async for stream, data in ch:
-        sink = sys.stderr.buffer if stream == STREAM_STDERR else sys.stdout.buffer
-        sink.write(data)
-        sink.flush()
-    return await ch.wait()
+    return await _exec_stream_channel(ch, stdin)
 
 
-async def _pty_interactive(conn: ComputeConnection, target: str) -> Tuple[int, Optional[str]]:
-    """Attach the local terminal to a PTY channel."""
+async def _open_interactive_pty(conn: ComputeConnection, target: str) -> Channel:
+    """Validate the local terminal and request an interactive PTY channel."""
     if os.name == "nt":  # pragma: no cover - platform guard
         raise NovemException("An interactive shell is not supported on Windows yet.")
-
-    import signal as signalmod
-    import termios
-    import tty
-
     if not sys.stdin.isatty():
         raise NovemException("An interactive shell requires a terminal. Use -R to run a command instead.")
 
     size = os.get_terminal_size()
-    ch = await conn.open_pty(target, rows=size.lines, cols=size.columns)
+    return await conn.open_pty(target, rows=size.lines, cols=size.columns)
+
+
+async def _pty_interactive(ch: Channel) -> Tuple[int, Optional[str]]:
+    """Attach the local terminal to an admitted PTY channel."""
+    import signal as signalmod
+    import termios
+    import tty
 
     loop = asyncio.get_event_loop()
     fd = sys.stdin.fileno()

--- a/novem/code/compute.py
+++ b/novem/code/compute.py
@@ -163,7 +163,6 @@ _HINTS = {
     "timeout": "The operation timed out.",
     "backpressure_timeout": "The data stream stalled. Wait briefly and try again.",
     "process_start_failed": "The command could not be started.",
-    "connection_failed": "The connection to the computer failed.",
     "protocol_error": "The compute protocol was rejected. Upgrade the CLI and try again.",
 }
 

--- a/novem/code/compute.py
+++ b/novem/code/compute.py
@@ -38,13 +38,10 @@ import os
 import secrets
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from novem.exceptions import NovemException
-
-if TYPE_CHECKING:  # pragma: no cover
-    from . import Computer
 
 PROTOCOL = "novem.compute.v1"
 PATH = "/ws-cu"
@@ -517,8 +514,7 @@ def _run_sync(coro: Any) -> Any:
         return asyncio.run(coro)
     coro.close()
     raise NovemException(
-        "A compute call was made from inside a running event loop. "
-        "Use the async API (Computer.connect()) instead."
+        "A compute call was made from inside a running event loop. " "Use the async API (Computer.connect()) instead."
     )
 
 

--- a/novem/code/compute.py
+++ b/novem/code/compute.py
@@ -35,8 +35,9 @@ import json
 import os
 import secrets
 import sys
+import threading
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
+from typing import IO, Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 from urllib.parse import urlparse
 
 from novem.exceptions import NovemException
@@ -45,14 +46,17 @@ PROTOCOL = "novem.compute.v1"
 PATH = "/ws-cu"
 MAX_DATA_BYTES = 64 * 1024
 BINARY_HEADER = 17
+MAX_MESSAGE_BYTES = 128 * 1024
+HELLO_TIMEOUT_SECONDS = 10.0
 
 # stream discriminators
 STREAM_DATA = 0  # pty/tcp bytes, and every client-to-server frame
 STREAM_STDOUT = 1
 STREAM_STDERR = 2
 
-# The server's stable error vocabulary. Anything outside this set is a
-# protocol violation on the server's side, not ours.
+# Error codes documented when this client was released. This set is
+# informational: a server may add codes during a rolling upgrade, so unknown
+# codes must pass through as terminal, non-retryable errors.
 ERROR_CODES = frozenset(
     {
         "invalid_request",
@@ -76,13 +80,15 @@ ERROR_CODES = frozenset(
 RETRYABLE_CODES = frozenset({"not_running", "upstream_unavailable", "timeout"})
 
 SIGNALS = frozenset({"HUP", "INT", "QUIT", "TERM", "KILL"})
+StdinSource = Union[str, bytes, bytearray, IO[Any]]
 
 
 class NovemComputeError(NovemException):
     """A scoped error from the compute protocol.
 
-    ``code`` is one of the server's stable codes; messages are sanitised
-    server-side and never carry run ids, addresses or command payloads.
+    Known codes may receive client hints or be retried during admission.
+    Unknown codes remain terminal so newer servers stay compatible with older
+    clients.
     """
 
     def __init__(self, code: str, message: str) -> None:
@@ -101,14 +107,47 @@ class NovemComputeError(NovemException):
         return f"{base}\n{hint}" if hint else base
 
 
+class NovemComputeTransportError(NovemException):
+    """The compute connection failed without a remote command exit status."""
+
+    def __init__(
+        self,
+        message: str,
+        close_code: Optional[int] = None,
+        *,
+        code: str = "connection_failed",
+        retryable: bool = False,
+    ) -> None:
+        self.close_code = close_code
+        self.code = code
+        self.retryable = retryable
+        detail = f"{message} (WebSocket close code {close_code})" if close_code is not None else message
+        super().__init__(detail)
+
+
 _HINTS = {
+    "invalid_request": "The compute request was rejected. Check the options and upgrade the CLI if it persists.",
     # A missing entitlement, no access, and no such computer are
     # deliberately indistinguishable — never claim "permission denied".
     "not_found": "The computer was not found, or you do not have access to it.",
     "not_running": "The computer is not running. Start it with: novem -c <name> -w status online",
     "agent_upgrade_required": "The computer is running an older agent. Restart it to pick up the new one.",
-    "limit_exceeded": "Too many open connections or channels. Close one and try again.",
+    "limit_exceeded": "The service is busy. Wait briefly and try again.",
     "upstream_unavailable": "The compute service is temporarily unavailable.",
+    "authorization_revoked": "Authorization for the session ended. Connect again.",
+    "computer_restarted": "The computer restarted during the session. Connect again.",
+    "timeout": "The operation timed out.",
+    "backpressure_timeout": "The data stream stalled. Wait briefly and try again.",
+    "process_start_failed": "The command could not be started.",
+    "connection_failed": "The connection to the computer failed.",
+    "protocol_error": "The compute protocol was rejected. Upgrade the CLI and try again.",
+}
+
+
+_CLOSE_REASONS = {
+    1001: ("session_ended", "The compute session ended."),
+    1008: ("protocol_error", "The compute protocol was rejected. Upgrade the CLI and try again."),
+    1011: ("upstream_unavailable", "The compute service ended the session."),
 }
 
 
@@ -167,9 +206,10 @@ def ws_url(api_root: str) -> str:
     path must match exactly — no trailing slash, query or fragment.
     """
     parsed = urlparse(api_root)
+    if parsed.scheme not in ("http", "https", "ws", "wss") or not parsed.netloc:
+        raise ValueError("api_root must include an http:// or https:// scheme and host")
     scheme = "wss" if parsed.scheme in ("https", "wss") else "ws"
-    netloc = parsed.netloc or parsed.path
-    return f"{scheme}://{netloc}{PATH}"
+    return f"{scheme}://{parsed.netloc}{PATH}"
 
 
 def target_for(owner: str, computer: str) -> str:
@@ -216,8 +256,9 @@ class Channel:
 
     async def send(self, payload: bytes) -> None:
         """Write bytes to the channel's stdin (or the TCP stream)."""
-        for i in range(0, len(payload), MAX_DATA_BYTES):
-            await self._conn._send_binary(encode_frame(self.id, payload[i : i + MAX_DATA_BYTES]))
+        chunk_size = self._conn.max_data_bytes
+        for i in range(0, len(payload), chunk_size):
+            await self._conn._send_binary(encode_frame(self.id, payload[i : i + chunk_size]))
 
     async def stdin_eof(self) -> None:
         """Close stdin without closing the channel.
@@ -276,10 +317,15 @@ class ComputeConnection:
         self._ws: Any = None
         self._session: Any = None
         self._reader: Optional["asyncio.Task[None]"] = None
+        self._watchdog: Optional["asyncio.Task[None]"] = None
         self.hello: Optional[Hello] = None
+        self.max_data_bytes = MAX_DATA_BYTES
+        self._receive_max_data_bytes = MAX_DATA_BYTES
+        self._last_inbound = 0.0
         self._channels: Dict[str, Channel] = {}
         self._pending: Dict[str, "asyncio.Future[Channel]"] = {}
         self._fatal: Optional[BaseException] = None
+        self._hello_event: Optional[asyncio.Event] = None
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -305,25 +351,59 @@ class ComputeConnection:
                 self._url,
                 protocols=(PROTOCOL,),
                 headers={"Authorization": f"Bearer {self._token}"},
-                max_msg_size=128 * 1024,
+                max_msg_size=MAX_MESSAGE_BYTES,
                 ssl=False if self._ignore_ssl else True,
-                autoping=True,
+                autoping=False,
             )
-        except Exception:
-            await self._session.close()
+            if self._ws.protocol != PROTOCOL:
+                raise NovemComputeTransportError("compute connection did not negotiate the expected protocol")
+
+            if self._debug:
+                print(f"WS: {self._url} ({PROTOCOL})", file=sys.stderr)
+
+            self._hello_event = asyncio.Event()
+            self._last_inbound = asyncio.get_running_loop().time()
+            self._reader = asyncio.create_task(self._read_loop())
+            await self._await_hello()
+            self._watchdog = asyncio.create_task(self._watch_liveness())
+            if self._fatal is not None:
+                raise self._fatal
+            return self
+        except NovemComputeTransportError:
+            await self.aclose()
             raise
-
-        if self._debug:
-            print(f"WS: {self._url} ({PROTOCOL})", file=sys.stderr)
-
-        self._reader = asyncio.ensure_future(self._read_loop())
-        await self._await_hello()
-        return self
+        except aiohttp.WSServerHandshakeError as e:
+            await self.aclose()
+            if e.status == 429:
+                raise NovemComputeTransportError(
+                    "compute connection is temporarily at capacity",
+                    code="limit_exceeded",
+                    retryable=True,
+                ) from e
+            if e.status == 503:
+                raise NovemComputeTransportError(
+                    "compute service is temporarily unavailable",
+                    code="upstream_unavailable",
+                    retryable=True,
+                ) from e
+            raise NovemComputeTransportError(f"compute connection could not be established (HTTP {e.status})") from e
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            await self.aclose()
+            raise NovemComputeTransportError("compute connection could not be established") from e
+        except BaseException:
+            await self.aclose()
+            raise
 
     async def __aexit__(self, *exc: Any) -> None:
         await self.aclose()
 
     async def aclose(self) -> None:
+        if self._watchdog:
+            self._watchdog.cancel()
+            try:
+                await self._watchdog
+            except (asyncio.CancelledError, Exception):
+                pass
         if self._reader:
             self._reader.cancel()
             try:
@@ -337,13 +417,15 @@ class ComputeConnection:
 
     async def _await_hello(self) -> None:
         # Clients must wait for and validate hello before opening channels.
-        for _ in range(200):
-            if self.hello is not None:
-                return
-            if self._fatal is not None:
-                raise self._fatal
-            await asyncio.sleep(0.01)
-        raise NovemException("compute connection did not send hello")
+        assert self._hello_event is not None
+        try:
+            await asyncio.wait_for(self._hello_event.wait(), timeout=HELLO_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            raise NovemComputeTransportError("compute connection did not send hello") from None
+        if self._fatal is not None:
+            raise self._fatal
+        if self.hello is None:
+            raise NovemComputeTransportError("compute connection did not send hello")
 
     # -- plumbing ----------------------------------------------------------
 
@@ -361,24 +443,56 @@ class ComputeConnection:
         aiohttp = self._aiohttp()
         try:
             async for msg in self._ws:
+                self._last_inbound = asyncio.get_running_loop().time()
                 if msg.type == aiohttp.WSMsgType.TEXT:
                     self._on_text(json.loads(msg.data))
                 elif msg.type == aiohttp.WSMsgType.BINARY:
                     stream, channel, payload = decode_frame(msg.data)
+                    if len(payload) > self._receive_max_data_bytes:
+                        raise ValueError("binary frame exceeds the negotiated payload limit")
                     ch = self._channels.get(channel)
                     if ch is not None:
                         ch._feed(stream, payload)
+                elif msg.type == aiohttp.WSMsgType.PING:
+                    await self._ws.pong(msg.data)
+                elif msg.type == aiohttp.WSMsgType.PONG:
+                    continue
                 elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
                     break
         except asyncio.CancelledError:
             raise
-        except Exception as e:  # pragma: no cover - transport failure
-            self._abort(e)
+        except Exception:  # pragma: no cover - exact transport failure varies by platform
+            self._abort(NovemComputeTransportError("compute connection failed"))
             return
-        self._abort(NovemException("compute connection closed"))
+        close_code = getattr(self._ws, "close_code", None)
+        reason, message = _CLOSE_REASONS.get(
+            close_code or 0,
+            ("connection_failed", "The connection to the computer was lost."),
+        )
+        self._abort(NovemComputeTransportError(message, close_code, code=reason))
+
+    async def _watch_liveness(self) -> None:
+        """Fail a connection whose advertised heartbeat has gone silent."""
+
+        assert self.hello is not None
+        heartbeat = float(self.hello.heartbeat_seconds)
+        interval = max(0.05, heartbeat)
+        loop = asyncio.get_running_loop()
+        while True:
+            await asyncio.sleep(interval)
+            if loop.time() - self._last_inbound <= heartbeat * 2:
+                continue
+            self._abort(NovemComputeTransportError("The connection to the computer stopped responding."))
+            if self._ws is not None:
+                await self._ws.close()
+            return
 
     def _abort(self, err: BaseException) -> None:
+        if self._fatal is not None:
+            return
         self._fatal = err
+        if self._hello_event is not None:
+            self._hello_event.set()
         for fut in self._pending.values():
             if not fut.done():
                 fut.set_exception(err)
@@ -392,22 +506,52 @@ class ComputeConnection:
         kind = msg.get("type")
 
         if kind == "hello":
-            self.hello = Hello(
+            hello = Hello(
                 protocol=msg.get("protocol", ""),
                 max_channels=int(msg.get("max_channels", 0)),
                 max_data_bytes=int(msg.get("max_data_bytes", 0)),
                 heartbeat_seconds=int(msg.get("heartbeat_seconds", 0)),
             )
-            if self.hello.protocol != PROTOCOL:
-                self._abort(NovemException(f"unexpected compute protocol {self.hello.protocol!r}"))
+            if hello.protocol != PROTOCOL:
+                self._abort(NovemComputeTransportError(f"unexpected compute protocol {hello.protocol!r}"))
+                return
+            if hello.max_channels <= 0:
+                self._abort(NovemComputeTransportError("compute connection sent an invalid channel limit"))
+                return
+            if hello.max_data_bytes <= 0 or hello.max_data_bytes + BINARY_HEADER > MAX_MESSAGE_BYTES:
+                self._abort(NovemComputeTransportError("compute connection sent an invalid payload limit"))
+                return
+            if hello.heartbeat_seconds <= 0:
+                self._abort(NovemComputeTransportError("compute connection sent an invalid heartbeat interval"))
+                return
+            self.hello = hello
+            self.max_data_bytes = min(MAX_DATA_BYTES, hello.max_data_bytes)
+            self._receive_max_data_bytes = hello.max_data_bytes
+            if self._hello_event is not None:
+                self._hello_event.set()
             return
 
         if kind == "ready":
-            fut = self._pending.pop(msg.get("request_id", ""), None)
-            channel = Channel(self, msg["channel"], msg.get("kind", ""))
+            request_id = msg.get("request_id", "")
+            fut = self._pending.get(request_id)
+            if fut is None or fut.done():
+                self._abort(NovemComputeTransportError("compute connection sent an unexpected ready message"))
+                return
+            channel_id = msg.get("channel")
+            if not isinstance(channel_id, str):
+                self._abort(NovemComputeTransportError("compute connection sent an invalid ready message"))
+                return
+            try:
+                valid_channel = len(_channel_bytes(channel_id)) == 16
+            except Exception:
+                valid_channel = False
+            if not valid_channel:
+                self._abort(NovemComputeTransportError("compute connection sent an invalid ready message"))
+                return
+            self._pending.pop(request_id, None)
+            channel = Channel(self, channel_id, msg.get("kind", ""))
             self._channels[channel.id] = channel
-            if fut is not None and not fut.done():
-                fut.set_result(channel)
+            fut.set_result(channel)
             return
 
         if kind == "error":
@@ -423,28 +567,39 @@ class ComputeConnection:
             ch = self._channels.get(msg.get("channel", ""))
             if ch is not None:
                 ch._fail(err)
+                self._channels.pop(ch.id, None)
             return
 
         if kind == "exit":
             ch = self._channels.get(msg.get("channel", ""))
             if ch is not None:
                 ch._finish(int(msg.get("code", 0)), msg.get("signal"))
+                self._channels.pop(ch.id, None)
             return
 
         if kind == "closed":
             ch = self._channels.get(msg.get("channel", ""))
             if ch is not None:
                 ch._closed_by_server()
+                self._channels.pop(ch.id, None)
             return
 
     # -- opening channels --------------------------------------------------
 
     async def _open(self, spec: Dict[str, Any]) -> Channel:
+        if self.hello is not None and len(self._channels) + len(self._pending) >= self.hello.max_channels:
+            raise NovemComputeError("limit_exceeded", "The connection has reached its channel limit")
         request_id = spec["request_id"]
         fut: "asyncio.Future[Channel]" = asyncio.get_event_loop().create_future()
         self._pending[request_id] = fut
-        await self._send_json(spec)
-        return await fut
+        try:
+            await self._send_json(spec)
+            return await fut
+        except BaseException:
+            self._pending.pop(request_id, None)
+            if not fut.done():
+                fut.cancel()
+            raise
 
     async def open_exec(
         self,
@@ -533,7 +688,13 @@ def _split_argv(argv: Any, mode: str) -> Tuple[str, List[str]]:
     return argv[0], list(argv[1:])
 
 
-async def _with_retry(open_channel: Any, use_channel: Any, connect: Any, retry_seconds: float) -> Any:
+async def _with_retry(
+    open_channel: Any,
+    use_channel: Any,
+    connect: Any,
+    retry_seconds: float,
+    on_retry: Optional[Callable[[NovemException], None]] = None,
+) -> Any:
     """Open and use a channel, retrying only failed admission attempts.
 
     A computer that has just been told to boot reports ``not_running`` (and
@@ -546,36 +707,210 @@ async def _with_retry(open_channel: Any, use_channel: Any, connect: Any, retry_s
 
     deadline = time.monotonic() + max(0.0, retry_seconds)
     delay = 0.5
+    notified = False
+
+    def notify(error: NovemException) -> None:
+        nonlocal notified
+        if on_retry is not None and not notified:
+            on_retry(error)
+        notified = True
+
+    # Retrying a failed upgrade is safe because no open request was sent. Once
+    # connected, explicit admission errors reuse that connection; a transport
+    # failure after an open request is never replayed because readiness may
+    # have been lost in transit.
     while True:
-        async with connect() as conn:
+        context = connect()
+        try:
+            conn = await context.__aenter__()
+        except NovemComputeTransportError as e:
+            if not e.retryable or time.monotonic() >= deadline:
+                raise
+            notify(e)
+            await asyncio.sleep(min(delay, max(0.0, deadline - time.monotonic())))
+            delay = min(delay * 1.5, 3.0)
+            continue
+        break
+
+    try:
+        while True:
             try:
                 channel = await open_channel(conn)
             except NovemComputeError as e:
                 if not e.retryable or time.monotonic() >= deadline:
                     raise
+                notify(e)
             else:
                 return await use_channel(channel)
-        await asyncio.sleep(delay)
-        delay = min(delay * 1.5, 3.0)
+            await asyncio.sleep(min(delay, max(0.0, deadline - time.monotonic())))
+            delay = min(delay * 1.5, 3.0)
+    finally:
+        await context.__aexit__(*sys.exc_info())
 
 
-async def _exec_collect_channel(ch: Channel, stdin: Optional[bytes]) -> ExecResult:
+async def _pump_stdin(ch: Channel, stdin: Optional[StdinSource]) -> None:
+    """Forward stdin incrementally without blocking the event loop.
+
+    File reads run in one bounded daemon worker. At most one chunk waits
+    locally while the previous chunk is written, and cancellation does not
+    wait for a pipe producer that keeps its end open.
+    """
+
+    if stdin is None:
+        await ch.stdin_eof()
+        return
+    if isinstance(stdin, str):
+        if stdin:
+            await ch.send(stdin.encode("utf-8"))
+        await ch.stdin_eof()
+        return
+    if isinstance(stdin, (bytes, bytearray)):
+        if stdin:
+            await ch.send(bytes(stdin))
+        await ch.stdin_eof()
+        return
+
+    loop = asyncio.get_running_loop()
+    queue: "asyncio.Queue[Tuple[Any, Optional[BaseException]]]" = asyncio.Queue()
+    may_read = threading.Event()
+    stopped = threading.Event()
+    may_read.set()
+
+    def deliver(chunk: Any, error: Optional[BaseException]) -> bool:
+        try:
+            loop.call_soon_threadsafe(queue.put_nowait, (chunk, error))
+            return True
+        except RuntimeError:
+            return False
+
+    def read_stdin() -> None:
+        reader = getattr(stdin, "read1", stdin.read)
+        while True:
+            may_read.wait()
+            may_read.clear()
+            if stopped.is_set():
+                return
+            try:
+                chunk = reader(MAX_DATA_BYTES)
+            except BaseException as e:
+                deliver(None, e)
+                return
+            if not deliver(chunk, None) or not chunk:
+                return
+
+    threading.Thread(target=read_stdin, name="novem-stdin", daemon=True).start()
+    try:
+        while True:
+            chunk, error = await queue.get()
+            if error is not None:
+                raise error
+            if not chunk:
+                break
+            payload = chunk.encode("utf-8") if isinstance(chunk, str) else bytes(chunk)
+            if payload:
+                await ch.send(payload)
+            may_read.set()
+        await ch.stdin_eof()
+    finally:
+        stopped.set()
+        may_read.set()
+
+
+_T = TypeVar("_T")
+
+
+async def _use_channel_with_stdin(
+    ch: Channel,
+    stdin: Optional[StdinSource],
+    consume: Callable[[], Awaitable[_T]],
+) -> _T:
+    """Pump input and consume output concurrently for one exec channel."""
+
+    pump: "asyncio.Task[None]" = asyncio.create_task(_pump_stdin(ch, stdin))
+    output: "asyncio.Future[_T]" = asyncio.ensure_future(consume())
+    try:
+        done, _ = await asyncio.wait((pump, output), return_when=asyncio.FIRST_COMPLETED)
+        if pump in done:
+            await pump
+        return await output
+    finally:
+        for task in (pump, output):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(pump, output, return_exceptions=True)
+
+
+async def _with_sigint_forwarding(ch: Channel, operation: Callable[[], Awaitable[_T]]) -> _T:
+    """Forward the first SIGINT to a command and abort locally on the second."""
+
+    if os.name == "nt" or threading.current_thread() is not threading.main_thread():
+        return await operation()
+
+    import signal as signalmod
+
+    loop = asyncio.get_running_loop()
+    pending: "asyncio.Queue[str]" = asyncio.Queue()
+    second_interrupt: "asyncio.Future[None]" = loop.create_future()
+    interrupts = 0
+
+    def on_sigint() -> None:
+        nonlocal interrupts
+        interrupts += 1
+        if interrupts == 1:
+            pending.put_nowait("INT")
+        elif not second_interrupt.done():
+            second_interrupt.set_result(None)
+
+    previous = signalmod.getsignal(signalmod.SIGINT)
+    try:
+        loop.add_signal_handler(signalmod.SIGINT, on_sigint)
+    except (NotImplementedError, RuntimeError, ValueError):  # pragma: no cover - platform/event-loop guard
+        return await operation()
+
+    async def forward() -> None:
+        while True:
+            await ch.signal(await pending.get())
+
+    sender: "asyncio.Task[None]" = asyncio.create_task(forward())
+    command: "asyncio.Future[_T]" = asyncio.ensure_future(operation())
+    try:
+        done, _ = await asyncio.wait((sender, command, second_interrupt), return_when=asyncio.FIRST_COMPLETED)
+        if command in done:
+            return await command
+        if sender in done:
+            await sender
+        raise KeyboardInterrupt
+    finally:
+        loop.remove_signal_handler(signalmod.SIGINT)
+        try:
+            signalmod.signal(signalmod.SIGINT, previous)
+        except (OSError, RuntimeError, ValueError):  # pragma: no cover - process teardown
+            pass
+        for task in (sender, command):
+            if not task.done():
+                task.cancel()
+        if not second_interrupt.done():
+            second_interrupt.cancel()
+        await asyncio.gather(sender, command, return_exceptions=True)
+
+
+async def _exec_collect_channel(ch: Channel, stdin: Optional[StdinSource]) -> ExecResult:
     """Collect output from an admitted exec channel."""
-    if stdin:
-        await ch.send(stdin)
-    await ch.stdin_eof()
 
-    out: List[bytes] = []
-    err: List[bytes] = []
-    async for stream, data in ch:
-        (err if stream == STREAM_STDERR else out).append(data)
-    code, signal = await ch.wait()
-    return ExecResult(
-        code=code,
-        signal=signal,
-        stdout=b"".join(out).decode("utf-8", "replace"),
-        stderr=b"".join(err).decode("utf-8", "replace"),
-    )
+    async def collect() -> ExecResult:
+        out: List[bytes] = []
+        err: List[bytes] = []
+        async for stream, data in ch:
+            (err if stream == STREAM_STDERR else out).append(data)
+        code, signal = await ch.wait()
+        return ExecResult(
+            code=code,
+            signal=signal,
+            stdout=b"".join(out).decode("utf-8", "replace"),
+            stderr=b"".join(err).decode("utf-8", "replace"),
+        )
+
+    return await _use_channel_with_stdin(ch, stdin, collect)
 
 
 async def _exec_collect(
@@ -585,24 +920,33 @@ async def _exec_collect(
     args: List[str],
     mode: str,
     cwd: str,
-    stdin: Optional[bytes],
+    stdin: Optional[StdinSource],
     timeout_seconds: int,
 ) -> ExecResult:
     ch = await conn.open_exec(target, command, args, mode=mode, cwd=cwd, timeout_seconds=timeout_seconds)
     return await _exec_collect_channel(ch, stdin)
 
 
-async def _exec_stream_channel(ch: Channel, stdin: Optional[bytes]) -> Tuple[int, Optional[str]]:
+async def _exec_stream_channel(
+    ch: Channel,
+    stdin: Optional[StdinSource],
+    forward_signals: bool = False,
+) -> Tuple[int, Optional[str]]:
     """Stream output from an admitted exec channel to local stdout/stderr."""
-    if stdin:
-        await ch.send(stdin)
-    await ch.stdin_eof()
 
-    async for stream, data in ch:
-        sink = sys.stderr.buffer if stream == STREAM_STDERR else sys.stdout.buffer
-        sink.write(data)
-        sink.flush()
-    return await ch.wait()
+    async def stream_output() -> Tuple[int, Optional[str]]:
+        async for stream, data in ch:
+            sink = sys.stderr.buffer if stream == STREAM_STDERR else sys.stdout.buffer
+            sink.write(data)
+            sink.flush()
+        return await ch.wait()
+
+    async def transfer() -> Tuple[int, Optional[str]]:
+        return await _use_channel_with_stdin(ch, stdin, stream_output)
+
+    if forward_signals:
+        return await _with_sigint_forwarding(ch, transfer)
+    return await transfer()
 
 
 async def _exec_stream(
@@ -612,7 +956,7 @@ async def _exec_stream(
     args: List[str],
     mode: str,
     cwd: str,
-    stdin: Optional[bytes],
+    stdin: Optional[StdinSource],
     timeout_seconds: int,
 ) -> Tuple[int, Optional[str]]:
     """Stream straight to local stdout/stderr and return the exit status."""
@@ -627,7 +971,10 @@ async def _open_interactive_pty(conn: ComputeConnection, target: str) -> Channel
     if not sys.stdin.isatty():
         raise NovemException("An interactive shell requires a terminal. Use -R to run a command instead.")
 
-    size = os.get_terminal_size()
+    try:
+        size = os.get_terminal_size(sys.stdin.fileno())
+    except OSError:
+        size = os.terminal_size((80, 24))
     return await conn.open_pty(target, rows=size.lines, cols=size.columns)
 
 
@@ -640,47 +987,99 @@ async def _pty_interactive(ch: Channel) -> Tuple[int, Optional[str]]:
     loop = asyncio.get_event_loop()
     fd = sys.stdin.fileno()
     saved = termios.tcgetattr(fd)
+    outbound: "asyncio.Queue[Tuple[str, Any]]" = asyncio.Queue()
+    reader_registered = False
+    stdin_ended = False
+
+    def register_reader() -> None:
+        nonlocal reader_registered
+        if not reader_registered and not stdin_ended:
+            loop.add_reader(fd, on_stdin)
+            reader_registered = True
 
     def on_winch(*_: Any) -> None:
         try:
-            new = os.get_terminal_size()
+            new = os.get_terminal_size(fd)
         except OSError:
-            return
-        asyncio.ensure_future(ch.resize(new.lines, new.columns))
+            new = os.terminal_size((80, 24))
+        outbound.put_nowait(("resize", (new.lines, new.columns)))
 
     def on_stdin() -> None:
-        data = os.read(fd, 8192)
-        if data:
-            asyncio.ensure_future(ch.send(data))
+        nonlocal reader_registered, stdin_ended
+        if reader_registered:
+            loop.remove_reader(fd)
+            reader_registered = False
+        try:
+            data = os.read(fd, 8192)
+        except OSError:
+            data = b""
+        if not data:
+            stdin_ended = True
+            outbound.put_nowait(("eof", None))
+            return
+        outbound.put_nowait(("data", data))
 
-    try:
-        tty.setraw(fd)
-        loop.add_signal_handler(signalmod.SIGWINCH, on_winch)
-        loop.add_reader(fd, on_stdin)
+    async def write_outbound() -> None:
+        while True:
+            kind, value = await outbound.get()
+            if kind == "data":
+                await ch.send(value)
+                register_reader()
+            elif kind == "resize":
+                rows, cols = value
+                await ch.resize(rows, cols)
+            else:
+                await ch.stdin_eof()
 
+    async def read_remote() -> Tuple[int, Optional[str]]:
         async for _stream, data in ch:
             sys.stdout.buffer.write(data)
             sys.stdout.buffer.flush()
         return await ch.wait()
+
+    try:
+        tty.setraw(fd)
+        loop.add_signal_handler(signalmod.SIGWINCH, on_winch)
+        register_reader()
+
+        writer = asyncio.create_task(write_outbound())
+        remote = asyncio.create_task(read_remote())
+        try:
+            done, _ = await asyncio.wait((writer, remote), return_when=asyncio.FIRST_COMPLETED)
+            if writer in done:
+                await writer
+            return await remote
+        finally:
+            for task in (writer, remote):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(writer, remote, return_exceptions=True)
     finally:
-        loop.remove_reader(fd)
+        if reader_registered:
+            loop.remove_reader(fd)
         try:
             loop.remove_signal_handler(signalmod.SIGWINCH)
         except (NotImplementedError, RuntimeError):  # pragma: no cover
             pass
-        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+        try:
+            termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+        except OSError:  # terminal already hung up
+            pass
 
 
 __all__ = [
     "PROTOCOL",
     "PATH",
     "MAX_DATA_BYTES",
+    "MAX_MESSAGE_BYTES",
     "STREAM_DATA",
     "STREAM_STDOUT",
     "STREAM_STDERR",
     "ERROR_CODES",
     "RETRYABLE_CODES",
     "NovemComputeError",
+    "NovemComputeTransportError",
+    "StdinSource",
     "Hello",
     "ExecResult",
     "Channel",

--- a/novem/code/compute.py
+++ b/novem/code/compute.py
@@ -1063,7 +1063,7 @@ async def _pty_interactive(ch: Channel) -> Tuple[int, Optional[str]]:
             pass
         try:
             termios.tcsetattr(fd, termios.TCSADRAIN, saved)
-        except OSError:  # terminal already hung up
+        except (OSError, termios.error):  # terminal already hung up
             pass
 
 

--- a/novem/code/compute.py
+++ b/novem/code/compute.py
@@ -123,12 +123,22 @@ class NovemComputeTransportError(NovemException):
         self.code = code
         self.retryable = retryable
         self.retry_after = retry_after
+        self._retry_after_exceeds_timeout = False
         detail = f"{message} (WebSocket close code {close_code})" if close_code is not None else message
         super().__init__(detail)
 
     @property
     def cli_message(self) -> str:
         base = str(self)
+        if self._retry_after_exceeds_timeout:
+            return (
+                f"{base}\nThe service requested a retry delay longer than --connect-timeout allows. "
+                "Increase --connect-timeout and try again."
+            )
+        # Close-frame messages are curated for the specific close code and
+        # already contain any action the user can take.
+        if self.close_code is not None:
+            return base
         hint = _HINTS.get(self.code)
         if not hint:
             return base
@@ -186,7 +196,12 @@ def _retry_after_seconds(value: Optional[str]) -> Optional[float]:
         if when.tzinfo is None:
             when = when.replace(tzinfo=timezone.utc)
         return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
-    return float(seconds) if seconds >= 0 else None
+    if seconds < 0:
+        return None
+    try:
+        return float(seconds)
+    except OverflowError:
+        return None
 
 
 @dataclass
@@ -765,9 +780,10 @@ async def _with_retry(
         retry_after = getattr(error, "retry_after", None)
         wait = max(delay, retry_after or 0.0)
         if retry_after is not None and retry_after > remaining:
-            if remaining:
-                await asyncio.sleep(remaining)
+            if isinstance(error, NovemComputeTransportError):
+                error._retry_after_exceeds_timeout = True
             return False
+        notify(error)
         await asyncio.sleep(min(wait, remaining))
         delay = min(delay * 1.5, 3.0)
         return True
@@ -783,7 +799,6 @@ async def _with_retry(
         except NovemComputeTransportError as e:
             if not e.retryable or time.monotonic() >= deadline:
                 raise
-            notify(e)
             if not await wait_before_retry(e):
                 raise
             continue
@@ -796,7 +811,6 @@ async def _with_retry(
             except NovemComputeError as e:
                 if not e.retryable or time.monotonic() >= deadline:
                     raise
-                notify(e)
                 if not await wait_before_retry(e):
                     raise
             else:

--- a/novem/job/__init__.py
+++ b/novem/job/__init__.py
@@ -1,7 +1,7 @@
 import os
 import re
 import sys
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from novem.exceptions import Novem403, Novem404, raise_on_response
 
@@ -325,8 +325,9 @@ class NovemJobAPI(NovemTreeSync, NovemAPI):
     def run(
         self,
         files: Optional[List[str]] = None,
-        input_dir: Optional[str] = None,
+        input_dir: Optional[Union[str, List[str]]] = None,
         output: Optional[str] = None,
+        output_file: Optional[str] = None,
     ) -> None:
         """
         Trigger a job run by posting to /data.
@@ -346,7 +347,10 @@ class NovemJobAPI(NovemTreeSync, NovemAPI):
 
         If *output* is provided, the response body is saved to that directory
         (created if necessary) using the filename from the server's
-        Content-Disposition header.
+        Content-Disposition header. *output_file* instead writes it to exactly
+        that path, which is what the CLI's ``-o @file.ext`` form asks for.
+
+        *input_dir* accepts a single directory or a list of them.
         """
         path = self._path("/data")
 
@@ -355,18 +359,24 @@ class NovemJobAPI(NovemTreeSync, NovemAPI):
 
         upload: Dict[str, str] = {}
 
-        if input_dir:
-            if not os.path.isdir(input_dir):
-                print(f"Error: input directory not found: {input_dir}")
+        input_dirs: List[str] = []
+        if isinstance(input_dir, str):
+            input_dirs = [input_dir]
+        elif input_dir:
+            input_dirs = list(input_dir)
+
+        for one_dir in input_dirs:
+            if not os.path.isdir(one_dir):
+                print(f"Error: input directory not found: {one_dir}")
                 sys.exit(1)
-            for root, dirs, walked in os.walk(input_dir):
+            for root, dirs, walked in os.walk(one_dir):
                 # skip hidden directories in-place so we don't descend into them
                 dirs[:] = [d for d in dirs if not d.startswith(".")]
                 for entry in walked:
                     if entry.startswith("."):
                         continue
                     fpath = os.path.join(root, entry)
-                    rel = os.path.relpath(fpath, input_dir).replace(os.sep, "/")
+                    rel = os.path.relpath(fpath, one_dir).replace(os.sep, "/")
                     upload[rel] = fpath
 
         if files:
@@ -392,7 +402,7 @@ class NovemJobAPI(NovemTreeSync, NovemAPI):
             ]
             if self._debug:
                 print(f"  files in:  {len(upload)} ({list(upload.keys())})")
-            r = self._session.post(path, files=multipart, stream=bool(output), timeout=(30, 1800))
+            r = self._session.post(path, files=multipart, stream=bool(output or output_file), timeout=(30, 1800))
         else:
             if self._debug:
                 print("  files in:  0")
@@ -400,7 +410,7 @@ class NovemJobAPI(NovemTreeSync, NovemAPI):
                 path,
                 headers={"Content-type": "application/json; charset=utf-8"},
                 data="{}",
-                stream=bool(output),
+                stream=bool(output or output_file),
                 timeout=(30, 1800),
             )
 
@@ -416,7 +426,17 @@ class NovemJobAPI(NovemTreeSync, NovemAPI):
                 print(f"Error: {r.text}")
             sys.exit(1)
 
-        if output:
+        if output_file:
+            # -o @file.ext: write the artifact to exactly this path
+            parent = os.path.dirname(os.path.abspath(output_file))
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            with open(output_file, "wb") as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            if self._debug:
+                print(f"  files out: 1 -> {output_file}")
+        elif output:
             os.makedirs(output, exist_ok=True)
             cd = r.headers.get("Content-Disposition", "")
             name = self._parse_filename(cd) or "output"

--- a/novem/utils.py
+++ b/novem/utils.py
@@ -480,52 +480,51 @@ def pretty_format_inner(
     return los
 
 
-def data_on_stdin() -> Optional[str]:
-    """
-    identify if there is data waiting on sys.stdin
-    """
+@dataclass
+class _StdinReadiness:
+    has_data: bool
+    is_test: bool
 
-    @dataclass
-    class Result:
-        has_data: bool
-        is_test: bool
 
-    def _data_ready() -> Result:
+def _stdin_readiness() -> _StdinReadiness:
+    try:
+        # use msvcrt on windows
+        import msvcrt
+
+        return _StdinReadiness(has_data=msvcrt.kbhit(), is_test=False)  # type: ignore
+    except ImportError:
         try:
-            # use msvcrt on windows
-            import msvcrt
+            # use select on linux
+            has_data = bool(select.select([sys.stdin], [], [], 0.0)[0])
+            return _StdinReadiness(has_data=has_data, is_test=False)
+        except io.UnsupportedOperation:
+            # Pytest replaces stdin with a stream that must not be read. A
+            # StringIO, on the other hand, is an intentional test input.
+            has_data = isinstance(sys.stdin, io.StringIO)
+            return _StdinReadiness(has_data=has_data, is_test=True)
 
-            r = msvcrt.kbhit()  # type: ignore
-            return Result(has_data=r, is_test=False)
 
-        except ImportError:
-            try:
-                # use select on linux
-                has_data = bool(
-                    select.select(
-                        [
-                            sys.stdin,
-                        ],
-                        [],
-                        [],
-                        0.0,
-                    )[0]
-                )
+def stream_on_stdin() -> Optional[Any]:
+    """Return stdin without consuming it when input should be forwarded.
 
-                return Result(has_data=has_data, is_test=False)
-            except io.UnsupportedOperation:
-                # We're going to assume that this is the pytest wrapper
-                # if sys.stdin is an instance of io.StringIO we are mocking data
-                # on stdin, so it should be true. else ignore.
-                has_data = isinstance(sys.stdin, io.StringIO)
-                return Result(has_data=has_data, is_test=True)
+    Real redirected stdin may not have bytes available at the instant the
+    command starts, so every non-interactive stream is returned. Callers that
+    need binary-safe incremental input can consume the returned buffer while
+    doing their other work concurrently.
+    """
 
-    r = _data_ready()
-
+    readiness = _stdin_readiness()
     is_noninteractive = not sys.stdin.isatty()
-    has_data = r.has_data or (is_noninteractive and not r.is_test)
+    has_data = readiness.has_data or (is_noninteractive and not readiness.is_test)
+    if not has_data:
+        return None
+    return getattr(sys.stdin, "buffer", sys.stdin)
 
-    ctnt = "".join(sys.stdin.readlines()) if has_data else ""
+
+def data_on_stdin() -> Optional[str]:
+    """Read text waiting on stdin, preserving the legacy buffered behavior."""
+
+    ctnt = "".join(sys.stdin.readlines()) if stream_on_stdin() is not None else ""
     return ctnt if ctnt else None
 
 

--- a/novem/vis/mail_sections.py
+++ b/novem/vis/mail_sections.py
@@ -1,5 +1,5 @@
 from inspect import Parameter, signature
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, get_args, get_origin
 
 from .plot import Plot
 
@@ -46,9 +46,10 @@ class NovemEmailSectionApi(NovemEmailSection):
                 continue
 
             v = locs[k]
+            annotation_args = get_args(p.annotation)
 
             # #find out if k is string, bool or list
-            if p.annotation is str or p.annotation is Optional[str]:
+            if p.annotation is str or set(annotation_args) == {str, type(None)}:
                 # This is a string argument, if value is not None add it
                 if v:
                     ts = f"{k.replace('_', ' ')}: {v}"
@@ -58,7 +59,7 @@ class NovemEmailSectionApi(NovemEmailSection):
                 ts = f"{k.replace('_', ' ')}: {'true' if v else 'false'}"
                 self._kwparams.append(ts)
 
-            elif p.annotation is List[str]:
+            elif get_origin(p.annotation) is list and annotation_args == (str,):
                 print("Treat as list of str")
 
         self._process_common_params(**kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
 events = [
     "python-socketio[asyncio_client]>=5.11.0",
 ]
+compute = [
+    # live computer connections (novem.compute.v1 over /ws-cu) need a
+    # WebSocket client that can set headers and negotiate a subprotocol
+    "aiohttp>=3.9",
+]
 mcp = [
     # novem.comments.MCP() targets the v1 API (mcp.server.fastmcp.FastMCP,
     # Tool.inputSchema).  mcp 2.0 removed both, so keep the extra on 1.x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ novem = "novem.cli:run_cli"
 
 [dependency-groups]
 dev = [
+    "aiohttp>=3.9",
     "flake8>=7.1.1",
     "isort>=5.13.2,<9.0.0",
     "mypy>=1.11.2",

--- a/tests/test_cli_code.py
+++ b/tests/test_cli_code.py
@@ -768,13 +768,81 @@ def test_session_verbs_are_computer_only(cli, requests_mock, fs):
         assert "only available for computers" in err
 
 
-def test_job_run_rejects_an_argv_tail_for_now(cli, requests_mock, fs):
+def test_job_run_rejects_run_arguments_for_now(cli, requests_mock, fs):
+    """Run arguments are specified but not shipped; say so rather than ignore."""
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/jobs/my-job", status_code=201)
+
+    for invocation in (
+        ("-j", "my-job", "-R", "--", "python", "main.py"),
+        ("-j", "my-job", "-R", "aapl"),
+    ):
+        try:
+            cli(*invocation)
+            assert False, "should exit"
+        except CliExit as e:
+            out, err = e.args
+            assert "does not take run arguments yet" in err
+            assert "future release" in err
+
+
+def test_job_run_points_at_dash_i_for_files(cli, requests_mock, fs):
+    """@file moved to -i; the old form must say where it went."""
     write_config(auth_req)
     requests_mock.register_uri("put", f"{api_root}code/jobs/my-job", status_code=201)
 
     try:
-        cli("-j", "my-job", "-R", "--", "python", "main.py")
+        cli("-j", "my-job", "-R", "@data.csv")
         assert False, "should exit"
     except CliExit as e:
         out, err = e.args
-        assert "not supported for jobs yet" in err
+        assert "moved to -i" in err
+        assert "-i @data.csv" in err
+
+
+def test_job_inputs_split_files_from_directories(cli, requests_mock, fs, monkeypatch):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/jobs/my-job", status_code=201)
+
+    seen = {}
+
+    def fake_run(self, files=None, input_dir=None, output=None, output_file=None):
+        seen.update(files=files, input_dir=input_dir, output=output, output_file=output_file)
+
+    monkeypatch.setattr("novem.Job.run", fake_run)
+
+    cli("-j", "my-job", "-R", "-i", "@a.csv", "-i", "./inputs", "-i", "@b.csv", "-o", "./out")
+
+    assert seen["files"] == ["@a.csv", "@b.csv"]
+    assert seen["input_dir"] == ["./inputs"]
+    assert seen["output"] == "./out"
+    assert seen["output_file"] is None
+
+
+def test_job_output_at_prefix_names_a_file(cli, requests_mock, fs, monkeypatch):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/jobs/my-job", status_code=201)
+
+    seen = {}
+
+    def fake_run(self, files=None, input_dir=None, output=None, output_file=None):
+        seen.update(output=output, output_file=output_file)
+
+    monkeypatch.setattr("novem.Job.run", fake_run)
+
+    cli("-j", "my-job", "-R", "-o", "@chart.png")
+
+    assert seen["output_file"] == "chart.png"
+    assert seen["output"] is None
+
+
+def test_job_rejects_multiple_outputs(cli, requests_mock, fs):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/jobs/my-job", status_code=201)
+
+    try:
+        cli("-j", "my-job", "-R", "-o", "@a.png", "-o", "@b.png")
+        assert False, "should exit"
+    except CliExit as e:
+        out, err = e.args
+        assert "only be given once" in err

--- a/tests/test_cli_code.py
+++ b/tests/test_cli_code.py
@@ -696,6 +696,28 @@ def test_computer_run_streams_and_exits_with_the_command_code(cli, requests_mock
     assert seen["argv"] == ["ls", "-la"]
 
 
+def test_computer_run_forwards_piped_stdin(cli, requests_mock, fs, monkeypatch):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    requests_mock.register_uri("get", f"{api_root}whoami", text="demouser")
+
+    seen = {}
+
+    def fake_stream(self, argv, **kwargs):
+        seen["stdin"] = kwargs.get("stdin")
+        return (0, None)
+
+    monkeypatch.setattr("novem.code.Computer.stream", fake_stream)
+
+    try:
+        cli("-c", "my-box", "-R", "--", "wc", "-l", stdin="a\nb\n")
+        assert False, "should exit with the command's code"
+    except CliExit as e:
+        assert e.code == 0
+
+    assert seen["stdin"] == "a\nb\n"
+
+
 def test_computer_run_reports_signals_shell_style(cli, requests_mock, fs, monkeypatch):
     write_config(auth_req)
     requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)

--- a/tests/test_cli_code.py
+++ b/tests/test_cli_code.py
@@ -78,6 +78,7 @@ def test_computer_list(cli, requests_mock, fs):
         [
             _vde(
                 "my-box",
+                name=None,
                 computer_type="permanent",
                 status="online",
                 running=True,
@@ -102,6 +103,8 @@ def test_computer_list(cli, requests_mock, fs):
     header = out.split("\n")[0]
     assert "Cpu" in header and "Mem" in header and "Disk" in header
     assert "2Gi" in out and "10Gi" in out
+    row = next(line for line in out.splitlines() if "my-box" in line)
+    assert " - " in row
 
 
 def test_image_list(cli, requests_mock, fs):
@@ -715,7 +718,30 @@ def test_computer_run_forwards_piped_stdin(cli, requests_mock, fs, monkeypatch):
     except CliExit as e:
         assert e.code == 0
 
-    assert seen["stdin"] == "a\nb\n"
+    # The CLI hands the stream off without decoding or waiting for EOF.
+    assert seen["stdin"].read() == "a\nb\n"
+
+
+def test_computer_transport_failure_has_a_distinct_exit_code(cli, requests_mock, fs, monkeypatch):
+    from novem.code import NovemComputeTransportError
+
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    requests_mock.register_uri("get", f"{api_root}whoami", text="demouser")
+
+    def fail_stream(self, argv, **kwargs):
+        raise NovemComputeTransportError("compute connection closed unexpectedly", 1011)
+
+    monkeypatch.setattr("novem.code.Computer.stream", fail_stream)
+
+    try:
+        cli("-c", "my-box", "-R", "--", "true")
+        assert False, "transport failures always exit"
+    except CliExit as e:
+        out, err = e.args
+        assert e.code == 255
+        assert "compute connection closed unexpectedly" in err
+        assert "1011" in err
 
 
 def test_computer_run_reports_signals_shell_style(cli, requests_mock, fs, monkeypatch):
@@ -730,6 +756,70 @@ def test_computer_run_reports_signals_shell_style(cli, requests_mock, fs, monkey
         assert False, "should exit"
     except CliExit as e:
         assert e.code == 143  # 128 + SIGTERM
+
+
+def test_computer_run_surfaces_unknown_signal(cli, requests_mock, fs, monkeypatch):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    requests_mock.register_uri("get", f"{api_root}whoami", text="demouser")
+    monkeypatch.setattr("novem.code.Computer.stream", lambda self, argv, **kw: (-1, "FUTURE"))
+
+    try:
+        cli("-c", "my-box", "-R", "--", "sleep", "100")
+        assert False, "should exit"
+    except CliExit as e:
+        out, err = e.args
+        assert e.code == 255
+        assert "unknown signal" in err
+        assert "FUTURE" in err
+
+
+def test_computer_run_ctrl_c_exits_130(cli, requests_mock, fs, monkeypatch):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    requests_mock.register_uri("get", f"{api_root}whoami", text="demouser")
+
+    def interrupt(self, argv, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("novem.code.Computer.stream", interrupt)
+
+    try:
+        cli("-c", "my-box", "-R", "--", "tail", "-f", "log")
+        assert False, "should exit"
+    except CliExit as e:
+        out, err = e.args
+        assert e.code == 130
+        assert "interrupted" in err
+
+
+def test_computer_wait_is_visible_and_configurable(cli, requests_mock, fs, monkeypatch):
+    from novem.code import NovemComputeError
+
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    requests_mock.register_uri("get", f"{api_root}whoami", text="demouser")
+    seen = {}
+
+    def fake_stream(self, argv, **kwargs):
+        seen.update(kwargs)
+        error = NovemComputeError("not_running", "Computer is starting")
+        kwargs["on_retry"](error)
+        kwargs["on_retry"](error)
+        return (0, None)
+
+    monkeypatch.setattr("novem.code.Computer.stream", fake_stream)
+
+    try:
+        cli("-c", "my-box", "--connect-timeout", "2.5", "-R", "--", "true")
+        assert False, "should exit"
+    except CliExit as e:
+        out, err = e.args
+        assert e.code == 0
+        assert err.count("waiting for the computer connection") == 1
+
+    assert seen["retry_seconds"] == 2.5
+    assert seen["forward_signals"] is True
 
 
 def test_computer_run_without_argv_explains_itself(cli, requests_mock, fs):
@@ -764,6 +854,51 @@ def test_computer_attach_calls_shell(cli, requests_mock, fs, monkeypatch):
     except CliExit as e:
         assert e.code == 0
     assert called.get("yes")
+
+
+def test_attach_without_a_computer_is_an_error(cli):
+    try:
+        cli("-A")
+        assert False, "should exit"
+    except CliExit as e:
+        out, err = e.args
+        assert e.code == 1
+        assert "requires a named computer" in err
+
+
+def test_bare_write_and_run_do_not_compete_for_stdin(cli, requests_mock, fs, monkeypatch):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    monkeypatch.setattr("novem.code.Computer.stream", lambda self, argv, **kwargs: (0, None))
+
+    try:
+        cli("-c", "my-box", "-w", "config/caption", "-R", "--", "cat", stdin="payload")
+        assert False, "should exit"
+    except CliExit as e:
+        out, err = e.args
+        assert e.code == 1
+        assert "cannot both read stdin" in err
+
+
+def test_bare_image_does_not_hide_run(cli, requests_mock, fs, monkeypatch):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    requests_mock.register_uri("get", f"{api_root}whoami", text="demouser")
+    called = {}
+
+    def fake_stream(self, argv, **kwargs):
+        called["argv"] = argv
+        return (0, None)
+
+    monkeypatch.setattr("novem.code.Computer.stream", fake_stream)
+
+    try:
+        cli("-c", "my-box", "--image", "-R", "--", "true")
+        assert False, "should exit"
+    except CliExit as e:
+        assert e.code == 0
+
+    assert called["argv"] == ["true"]
 
 
 def test_attach_and_run_are_mutually_exclusive(cli, requests_mock, fs):

--- a/tests/test_cli_code.py
+++ b/tests/test_cli_code.py
@@ -5,6 +5,7 @@ Listing goes through GraphQL (mocked at the /gql endpoint); everything else
 is REST against code/{collection}/{id} (mocked with requests_mock).
 """
 
+import sys
 from functools import partial
 
 from novem.cli.gql import _get_gql_endpoint
@@ -636,3 +637,144 @@ def test_plot_share_and_read_untouched(cli, requests_mock, fs):
     out, err = cli("-p", "my-plot", "-s", "public", "-C", "-r", "url")
     assert shared.get("yes")
     assert out == "https://novem.no/p/x"
+
+
+# --- computer sessions: -R and -A -----------------------------------------------
+
+
+def test_computer_image_shorthand(cli, requests_mock, fs):
+    """--image on a selected computer writes config/image."""
+    write_config(auth_req)
+
+    written = {}
+
+    def on_write(request, context):
+        written["image"] = request.text
+        context.status_code = 200
+        return ""
+
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    requests_mock.register_uri("post", f"{api_root}code/computers/my-box/config/image", text=on_write)
+
+    out, err = cli("-c", "my-box", "-C", "--image", "@novem/base")
+    assert written["image"] == "@novem/base"
+
+
+def test_computer_image_bare_reads_it_back(cli, requests_mock, fs):
+    write_config(auth_req)
+
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    requests_mock.register_uri("get", f"{api_root}code/computers/my-box/config/image", text="@novem/base\n")
+
+    out, err = cli("-c", "my-box", "--image")
+    assert out == "@novem/base\n"
+
+
+def test_computer_run_streams_and_exits_with_the_command_code(cli, requests_mock, fs, monkeypatch):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    requests_mock.register_uri("get", f"{api_root}whoami", text="demouser")
+
+    seen = {}
+
+    def fake_stream(self, argv, **kwargs):
+        seen["argv"] = argv
+        seen["stdin"] = kwargs.get("stdin")
+        sys.stdout.write("hello\n")
+        return (7, None)
+
+    monkeypatch.setattr("novem.code.Computer.stream", fake_stream)
+
+    try:
+        cli("-c", "my-box", "-R", "--", "ls", "-la")
+        assert False, "should exit with the command's code"
+    except CliExit as e:
+        out, err = e.args
+        assert e.code == 7
+        assert "hello" in out
+
+    assert seen["argv"] == ["ls", "-la"]
+
+
+def test_computer_run_reports_signals_shell_style(cli, requests_mock, fs, monkeypatch):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    requests_mock.register_uri("get", f"{api_root}whoami", text="demouser")
+
+    monkeypatch.setattr("novem.code.Computer.stream", lambda self, argv, **kw: (-1, "TERM"))
+
+    try:
+        cli("-c", "my-box", "-R", "--", "sleep", "100")
+        assert False, "should exit"
+    except CliExit as e:
+        assert e.code == 143  # 128 + SIGTERM
+
+
+def test_computer_run_without_argv_explains_itself(cli, requests_mock, fs):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+
+    try:
+        cli("-c", "my-box", "-R")
+        assert False, "should exit"
+    except CliExit as e:
+        out, err = e.args
+        assert "needs a command" in err
+        assert "-R -- ls -la" in err
+
+
+def test_computer_attach_calls_shell(cli, requests_mock, fs, monkeypatch):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+    requests_mock.register_uri("get", f"{api_root}whoami", text="demouser")
+
+    called = {}
+
+    def fake_shell(self, **kwargs):
+        called["yes"] = True
+        return (0, None)
+
+    monkeypatch.setattr("novem.code.Computer.shell", fake_shell)
+
+    try:
+        cli("-c", "my-box", "-A")
+        assert False, "should exit"
+    except CliExit as e:
+        assert e.code == 0
+    assert called.get("yes")
+
+
+def test_attach_and_run_are_mutually_exclusive(cli, requests_mock, fs):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/computers/my-box", status_code=201)
+
+    try:
+        cli("-c", "my-box", "-A", "-R", "--", "ls")
+        assert False, "should exit"
+    except CliExit as e:
+        out, err = e.args
+        assert "cannot be combined" in err
+
+
+def test_session_verbs_are_computer_only(cli, requests_mock, fs):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/spaces/my-space", status_code=201)
+
+    try:
+        cli("-s", "my-space", "-A")
+        assert False, "should exit"
+    except CliExit as e:
+        out, err = e.args
+        assert "only available for computers" in err
+
+
+def test_job_run_rejects_an_argv_tail_for_now(cli, requests_mock, fs):
+    write_config(auth_req)
+    requests_mock.register_uri("put", f"{api_root}code/jobs/my-job", status_code=201)
+
+    try:
+        cli("-j", "my-job", "-R", "--", "python", "main.py")
+        assert False, "should exit"
+    except CliExit as e:
+        out, err = e.args
+        assert "not supported for jobs yet" in err

--- a/tests/test_cli_selectors.py
+++ b/tests/test_cli_selectors.py
@@ -378,6 +378,10 @@ def test_argv_tail_split():
     # the tail is verbatim, including things that look like flags and a second --
     assert split_argv_tail(["-R", "--", "sh", "-c", "x -- y"])[1] == ["sh", "-c", "x -- y"]
     assert split_argv_tail(["-R", "--", "--weird"])[1] == ["--weird"]
+    # A separator on an ordinary command remains argparse's responsibility;
+    # it must not silently discard everything after it.
+    ordinary = ["-p", "plot", "-w", "config/caption", "--", "-5%"]
+    assert split_argv_tail(ordinary) == (ordinary, None)
 
 
 def test_setup_exposes_argv():

--- a/tests/test_cli_selectors.py
+++ b/tests/test_cli_selectors.py
@@ -32,7 +32,7 @@ def test_c_needs_no_promotion():
 
 
 def test_first_i_becomes_image_selector():
-    assert promoted(["-i"]) == ["--image"]
+    assert promoted(["-i"]) == ["--image-select"]
 
 
 def test_only_the_first_selector_is_promoted():
@@ -100,7 +100,7 @@ def test_org_group_bare_selector_promotes():
     # bare -s with -O/-G means "list the group's spaces"
     assert promoted(["-O", "myorg", "-G", "mygroup", "-s"]) == ["-O", "myorg", "-G", "mygroup", "--space"]
     assert promoted(["-O", "myorg", "-G", "mygroup", "-r"]) == ["-O", "myorg", "-G", "mygroup", "--repo"]
-    assert promoted(["-O", "myorg", "-G", "mygroup", "-i"]) == ["-O", "myorg", "-G", "mygroup", "--image"]
+    assert promoted(["-O", "myorg", "-G", "mygroup", "-i"]) == ["-O", "myorg", "-G", "mygroup", "--image-select"]
 
 
 def test_org_group_valued_selector_keeps_legacy():
@@ -328,3 +328,71 @@ def test_path_shaped_computer_name_is_rejected():
     # a plain computer name is untouched
     _, args = setup(["-c", "my-box"])
     assert args["computer"] == "my-box"
+
+
+# --- --image is overloaded on the same rule as the shorts -------------------
+
+
+def test_long_image_promotes_when_unclaimed():
+    # nothing else claims the invocation: --image selects an image
+    assert promoted(["--image"]) == ["--image-select"]
+    assert promoted(["--image", "myimg"]) == ["--image-select", "myimg"]
+    assert promoted(["--image=myimg"]) == ["--image-select=myimg"]
+
+
+def test_long_image_is_config_setter_once_claimed():
+    # -c claims the invocation, so --image sets the computer's image
+    argv = ["-c", "my-box", "--image", "@novem/base"]
+    assert promoted(argv) == argv
+    argv = ["-p", "my-plot", "--image", "x"]
+    assert promoted(argv) == argv
+
+
+def test_only_the_first_image_promotes():
+    assert promoted(["--image", "a", "--image", "b"]) == ["--image-select", "a", "--image", "b"]
+
+
+def test_setup_image_selector_and_setter():
+    _, args = setup(["--image", "myimg"])
+    assert args["image"] == "myimg"
+    assert args["image_ref"] == ""  # not given in this invocation
+
+    _, args = setup(["-c", "box", "--image", "@novem/base"])
+    assert args["computer"] == "box"
+    assert args["image"] == ""  # no image selected
+    assert args["image_ref"] == "@novem/base"
+
+    # bare --image on a selected resource reads it back
+    _, args = setup(["-c", "box", "--image"])
+    assert args["image_ref"] is None
+
+
+# --- the -- argv tail -------------------------------------------------------
+
+
+def test_argv_tail_split():
+    from novem.cli.setup import split_argv_tail
+
+    assert split_argv_tail(["-c", "box", "-R", "--", "ls", "-la"]) == (["-c", "box", "-R"], ["ls", "-la"])
+    assert split_argv_tail(["-c", "box", "-R"]) == (["-c", "box", "-R"], None)
+    # the tail is verbatim, including things that look like flags and a second --
+    assert split_argv_tail(["-R", "--", "sh", "-c", "x -- y"])[1] == ["sh", "-c", "x -- y"]
+    assert split_argv_tail(["-R", "--", "--weird"])[1] == ["--weird"]
+
+
+def test_setup_exposes_argv():
+    _, args = setup(["-c", "box", "-R", "--", "ls", "-la"])
+    assert args["computer"] == "box"
+    assert args["run_job"] == []
+    assert args["argv"] == ["ls", "-la"]
+
+    _, args = setup(["-c", "box", "-R"])
+    assert args["argv"] is None
+
+
+def test_setup_attach():
+    _, args = setup(["-c", "box", "-A"])
+    assert args["computer"] == "box"
+    assert args["attach"] is True
+    _, args = setup(["-c", "box"])
+    assert args["attach"] is False

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -116,6 +116,13 @@ def test_computer_status_and_config(requests_mock):
     assert gcheck["config/memory"] == "4Gi"
 
 
+def test_computer_compute_connection_uses_resolved_ssl_setting():
+    computer = Computer("box", config_path=CONFIG_FILE, ignore_ssl=True, create=False)
+    connection = computer.connect()
+
+    assert connection._ignore_ssl is True
+
+
 def test_image_read_only(requests_mock):
     api_root = _api_root()
     gcheck = {"create": False}

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -123,6 +123,12 @@ def test_computer_compute_connection_uses_resolved_ssl_setting():
     assert connection._ignore_ssl is True
 
 
+def test_computer_without_a_resolved_token_builds_a_clean_connection():
+    computer = Computer("box", api_root="https://api.example.test/v1/", ignore_config=True, create=False)
+    assert computer.token is None
+    assert computer.connect()._token == ""
+
+
 def test_image_read_only(requests_mock):
     api_root = _api_root()
     gcheck = {"create": False}

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -1,8 +1,8 @@
 """Tests for the novem.compute.v1 client.
 
-The protocol tests run against a real WebSocket server that speaks the
-server's side of the contract, so the aiohttp client path, the frame codec
-and the message dispatch are all exercised for real rather than mocked.
+The integration tests use a local WebSocket peer speaking the public
+protocol, exercising the aiohttp client path, frame codec and message
+dispatch without mocking the transport.
 """
 
 import asyncio
@@ -10,7 +10,9 @@ import base64
 import json
 import secrets
 
+import aiohttp
 import pytest
+from aiohttp import web
 
 from novem.code.compute import (
     MAX_DATA_BYTES,
@@ -19,15 +21,14 @@ from novem.code.compute import (
     STREAM_STDOUT,
     ComputeConnection,
     NovemComputeError,
+    _exec_collect_channel,
     _split_argv,
+    _with_retry,
     decode_frame,
     encode_frame,
     target_for,
     ws_url,
 )
-
-aiohttp = pytest.importorskip("aiohttp")
-web = pytest.importorskip("aiohttp.web")
 
 TARGET = "/v1/users/alice/code/computers/box"
 
@@ -76,7 +77,7 @@ def test_split_argv():
         _split_argv([], "argv")
 
 
-def test_open_validation_matches_server_rules():
+def test_open_validation_matches_protocol_rules():
     async def check():
         conn = ComputeConnection("ws://unused/ws-cu", "nut-x")
         with pytest.raises(ValueError, match="shell mode"):
@@ -245,6 +246,86 @@ def test_error_before_ready_raises_with_stable_code():
     assert err.code == "not_running"
     assert err.retryable is True
     assert "novem -c" in err.cli_message  # the hint tells you how to start it
+
+
+def test_retry_reopens_after_retryable_admission_error():
+    attempts = 0
+
+    async def script(ws, msg, server):
+        nonlocal attempts
+        if msg["type"] != "open":
+            return
+
+        attempts += 1
+        if attempts == 1:
+            await ws.send_str(
+                json.dumps(
+                    {
+                        "type": "error",
+                        "request_id": msg["request_id"],
+                        "code": "not_running",
+                        "message": "Computer is starting",
+                    }
+                )
+            )
+            return
+
+        channel = _channel()
+        await ws.send_str(
+            json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": channel, "kind": "exec"})
+        )
+        await ws.send_str(json.dumps({"type": "exit", "channel": channel, "code": 0, "signal": None}))
+
+    async def body(url):
+        return await _with_retry(
+            lambda conn: conn.open_exec(TARGET, "true"),
+            lambda channel: _exec_collect_channel(channel, None),
+            lambda: ComputeConnection(url, "nut-x"),
+            1.0,
+        )
+
+    result = _drive(FakeServer(script), body)
+    assert result.code == 0
+    assert attempts == 2
+
+
+def test_retry_does_not_replay_a_command_after_ready():
+    attempts = 0
+
+    async def script(ws, msg, server):
+        nonlocal attempts
+        if msg["type"] != "open":
+            return
+
+        attempts += 1
+        channel = _channel()
+        await ws.send_str(
+            json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": channel, "kind": "exec"})
+        )
+        await ws.send_str(
+            json.dumps(
+                {
+                    "type": "error",
+                    "channel": channel,
+                    "code": "upstream_unavailable",
+                    "message": "Connection was interrupted",
+                }
+            )
+        )
+
+    async def body(url):
+        with pytest.raises(NovemComputeError) as exc_info:
+            await _with_retry(
+                lambda conn: conn.open_exec(TARGET, "touch", ["marker"]),
+                lambda channel: _exec_collect_channel(channel, None),
+                lambda: ComputeConnection(url, "nut-x"),
+                1.0,
+            )
+        return exc_info.value
+
+    error = _drive(FakeServer(script), body)
+    assert error.code == "upstream_unavailable"
+    assert attempts == 1
 
 
 def test_not_found_never_claims_permission_denied():

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -42,6 +42,7 @@ from novem.code.compute import (
     target_for,
     ws_url,
 )
+from novem.exceptions import NovemException
 
 TARGET = "/v1/users/alice/code/computers/box"
 
@@ -127,6 +128,14 @@ def test_unknown_error_codes_pass_through_as_terminal():
         assert exc_info.value.cli_message == "A newer server reported an error"
 
     asyncio.run(check())
+
+
+def test_transport_errors_include_their_code_hint():
+    error = NovemComputeTransportError("compute connection is temporarily at capacity", code="limit_exceeded")
+
+    assert error.cli_message == (
+        "compute connection is temporarily at capacity\n" "The service is busy. Wait briefly and try again."
+    )
 
 
 def test_unknown_or_invalid_ready_is_a_transport_error():
@@ -362,6 +371,45 @@ def test_output_is_consumed_while_file_stdin_is_still_open():
     asyncio.run(check())
 
 
+def test_command_exit_cancels_an_unbounded_stdin_pump():
+    class EndlessInput:
+        def __init__(self):
+            self.reads = 0
+
+        def read(self, size):
+            self.reads += 1
+            return b"input\n"
+
+    class RecordingChannel:
+        def __init__(self):
+            self.data = []
+            self.received = asyncio.Event()
+            self.eof = False
+
+        async def send(self, data):
+            self.data.append(data)
+            self.received.set()
+
+        async def stdin_eof(self):
+            self.eof = True
+
+    async def check():
+        source = EndlessInput()
+        channel = RecordingChannel()
+
+        async def consume():
+            await channel.received.wait()
+            return "command exited"
+
+        result = await asyncio.wait_for(_use_channel_with_stdin(channel, source, consume), timeout=1)
+        assert result == "command exited"
+        assert source.reads >= 1
+        assert channel.data
+        assert channel.eof is False
+
+    asyncio.run(check())
+
+
 def test_first_sigint_is_forwarded_to_the_command(monkeypatch):
     class RecordingChannel:
         def __init__(self):
@@ -491,6 +539,33 @@ def test_pty_hangup_sends_eof_once_without_spinning(monkeypatch):
         os.close(slave_fd)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="PTY handling is Unix-only")
+@pytest.mark.parametrize("failure_point", ["tcgetattr", "setraw"])
+def test_pty_setup_failure_has_a_clear_error(monkeypatch, failure_point):
+    import termios
+    import tty
+
+    class Stdin:
+        @staticmethod
+        def fileno():
+            return 42
+
+    def unavailable(*args):
+        raise termios.error(5, "Input/output error")
+
+    monkeypatch.setattr(sys, "stdin", Stdin())
+    if failure_point == "tcgetattr":
+        monkeypatch.setattr(termios, "tcgetattr", unavailable)
+    else:
+        monkeypatch.setattr(termios, "tcgetattr", lambda fd: object())
+        monkeypatch.setattr(termios, "tcsetattr", lambda *args: None)
+        monkeypatch.setattr(tty, "setraw", unavailable)
+
+    with pytest.raises(NovemException, match="local terminal became unavailable") as exc_info:
+        asyncio.run(_pty_interactive(object()))
+    assert isinstance(exc_info.value.__cause__, termios.error)
+
+
 # --- protocol, against a real server ----------------------------------------
 
 
@@ -510,7 +585,11 @@ class FakeServer:
     async def handler(self, request):
         self.connections += 1
         if self.reject_statuses:
-            return web.Response(status=self.reject_statuses.pop(0))
+            rejection = self.reject_statuses.pop(0)
+            if isinstance(rejection, tuple):
+                status, headers = rejection
+                return web.Response(status=status, headers=headers)
+            return web.Response(status=rejection)
         self.auth = request.headers.get("Authorization")
         self.subprotocol = request.headers.get("Sec-WebSocket-Protocol")
         ws = web.WebSocketResponse(protocols=self.protocols)
@@ -728,6 +807,64 @@ def test_retryable_handshake_failure_reconnects_before_any_open():
     assert len(retries) == 1
     assert isinstance(retries[0], NovemComputeTransportError)
     assert retries[0].code == "upstream_unavailable"
+
+
+def test_429_handshake_exposes_retry_after_and_hint():
+    async def script(ws, msg, server):
+        pass
+
+    server = FakeServer(script, reject_statuses=[(429, {"Retry-After": "7"})])
+
+    async def body(url):
+        connection = ComputeConnection(url, "nut-x")
+        with pytest.raises(NovemComputeTransportError) as exc_info:
+            await connection.__aenter__()
+        return exc_info.value
+
+    error = _drive(server, body)
+    assert error.code == "limit_exceeded"
+    assert error.retryable is True
+    assert error.retry_after == 7.0
+    assert "Wait briefly and try again" in error.cli_message
+
+
+def test_retryable_transport_honours_retry_after(monkeypatch):
+    attempts = 0
+    waits = []
+
+    class Context:
+        async def __aenter__(self):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise NovemComputeTransportError(
+                    "temporarily at capacity",
+                    code="limit_exceeded",
+                    retryable=True,
+                    retry_after=2.0,
+                )
+            return "connection"
+
+        async def __aexit__(self, *exc):
+            pass
+
+    async def sleep(delay):
+        waits.append(delay)
+
+    async def open_channel(connection):
+        assert connection == "connection"
+        return "channel"
+
+    async def use_channel(channel):
+        assert channel == "channel"
+        return "done"
+
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+    result = asyncio.run(_with_retry(open_channel, use_channel, Context, 5.0))
+
+    assert result == "done"
+    assert attempts == 2
+    assert waits == [2.0]
 
 
 def test_handshake_validation_failure_closes_all_resources(monkeypatch):

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -160,7 +160,9 @@ def test_exec_streams_output_and_exit_status():
         if msg["type"] == "open":
             ch = _channel()
             gw.channel = ch
-            await ws.send_str(json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"}))
+            await ws.send_str(
+                json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"})
+            )
             await ws.send_bytes(encode_frame(ch, b"out\n", STREAM_STDOUT))
             await ws.send_bytes(encode_frame(ch, b"err\n", STREAM_STDERR))
             await ws.send_str(json.dumps({"type": "exit", "channel": ch, "code": 3, "signal": None}))
@@ -201,7 +203,9 @@ def test_signalled_process_reports_signal():
     async def script(ws, msg, gw):
         if msg["type"] == "open":
             ch = _channel()
-            await ws.send_str(json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"}))
+            await ws.send_str(
+                json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"})
+            )
             # a signalled process carries -1 with a signal name
             await ws.send_str(json.dumps({"type": "exit", "channel": ch, "code": -1, "signal": "TERM"}))
 
@@ -276,7 +280,9 @@ def test_stdin_is_sent_before_eof():
         if msg["type"] == "open":
             ch = _channel()
             gw.channel = ch
-            await ws.send_str(json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"}))
+            await ws.send_str(
+                json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"})
+            )
             await ws.send_str(json.dumps({"type": "exit", "channel": ch, "code": 0, "signal": None}))
 
     server = FakeServer(script)
@@ -300,7 +306,9 @@ def test_large_stdin_is_chunked_to_the_frame_limit():
     async def script(ws, msg, gw):
         if msg["type"] == "open":
             ch = _channel()
-            await ws.send_str(json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"}))
+            await ws.send_str(
+                json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"})
+            )
             await ws.send_str(json.dumps({"type": "exit", "channel": ch, "code": 0, "signal": None}))
 
     server = FakeServer(script)

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -138,6 +138,12 @@ def test_transport_errors_include_their_code_hint():
     )
 
 
+def test_connection_failure_does_not_repeat_a_generic_hint():
+    error = NovemComputeTransportError("The connection to the computer stopped responding.")
+
+    assert error.cli_message == "The connection to the computer stopped responding."
+
+
 def test_unknown_or_invalid_ready_is_a_transport_error():
     async def check():
         unknown = ComputeConnection("ws://unused/ws-cu", "nut-x")

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -1,0 +1,320 @@
+"""Tests for the novem.compute.v1 client.
+
+The protocol tests run against a real WebSocket server that speaks the
+server's side of the contract, so the aiohttp client path, the frame codec
+and the message dispatch are all exercised for real rather than mocked.
+"""
+
+import asyncio
+import base64
+import json
+import secrets
+
+import pytest
+
+from novem.code.compute import (
+    MAX_DATA_BYTES,
+    PROTOCOL,
+    STREAM_STDERR,
+    STREAM_STDOUT,
+    ComputeConnection,
+    NovemComputeError,
+    _split_argv,
+    decode_frame,
+    encode_frame,
+    target_for,
+    ws_url,
+)
+
+aiohttp = pytest.importorskip("aiohttp")
+web = pytest.importorskip("aiohttp.web")
+
+TARGET = "/v1/users/alice/code/computers/box"
+
+
+# --- pure units --------------------------------------------------------------
+
+
+def test_frame_round_trip():
+    channel = base64.urlsafe_b64encode(secrets.token_bytes(16)).decode().rstrip("=")
+    frame = encode_frame(channel, b"hello", STREAM_STDOUT)
+    assert len(frame) == 17 + 5
+    assert decode_frame(frame) == (STREAM_STDOUT, channel, b"hello")
+
+
+def test_frame_rejects_empty_and_oversized():
+    channel = base64.urlsafe_b64encode(secrets.token_bytes(16)).decode().rstrip("=")
+    with pytest.raises(ValueError, match="empty"):
+        encode_frame(channel, b"")
+    with pytest.raises(ValueError, match="exceeds"):
+        encode_frame(channel, b"x" * (MAX_DATA_BYTES + 1))
+
+
+def test_decode_rejects_short_frame():
+    with pytest.raises(ValueError, match="too short"):
+        decode_frame(b"\x00" + b"y" * 16)  # header only, no payload
+
+
+def test_ws_url_is_host_rooted():
+    # /ws-cu is served at the host root, not under /v1
+    assert ws_url("https://api.novem.io/v1/") == "wss://api.novem.io/ws-cu"
+    assert ws_url("http://localhost:9090/v1/") == "ws://localhost:9090/ws-cu"
+
+
+def test_target_is_canonical():
+    # the short /v1/code/... form is not accepted here
+    assert target_for("alice", "box") == TARGET
+
+
+def test_split_argv():
+    assert _split_argv(["ls", "-la"], "argv") == ("ls", ["-la"])
+    assert _split_argv("ls", "argv") == ("ls", [])
+    assert _split_argv("ps aux | wc -l", "shell") == ("ps aux | wc -l", [])
+    with pytest.raises(ValueError, match="single command string"):
+        _split_argv(["ps", "aux"], "shell")
+    with pytest.raises(ValueError, match="command is required"):
+        _split_argv([], "argv")
+
+
+def test_open_validation_matches_server_rules():
+    async def check():
+        conn = ComputeConnection("ws://unused/ws-cu", "nut-x")
+        with pytest.raises(ValueError, match="shell mode"):
+            await conn.open_exec(TARGET, "ls", ["-la"], mode="shell")
+        with pytest.raises(ValueError, match="relative executable"):
+            await conn.open_exec(TARGET, "./run.sh")
+        with pytest.raises(ValueError, match="cwd must be absolute"):
+            await conn.open_exec(TARGET, "ls", cwd="rel/path")
+
+    asyncio.run(check())
+
+
+# --- protocol, against a real server ----------------------------------------
+
+
+class FakeServer:
+    """A minimal server-side implementation of novem.compute.v1."""
+
+    def __init__(self, script):
+        self.script = script
+        self.seen = []
+        self.auth = None
+        self.subprotocol = None
+
+    async def handler(self, request):
+        self.auth = request.headers.get("Authorization")
+        self.subprotocol = request.headers.get("Sec-WebSocket-Protocol")
+        ws = web.WebSocketResponse(protocols=(PROTOCOL,))
+        await ws.prepare(request)
+
+        await ws.send_str(
+            json.dumps(
+                {
+                    "type": "hello",
+                    "protocol": PROTOCOL,
+                    "max_channels": 16,
+                    "max_data_bytes": MAX_DATA_BYTES,
+                    "heartbeat_seconds": 30,
+                }
+            )
+        )
+
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                payload = json.loads(msg.data)
+                self.seen.append(payload)
+                await self.script(ws, payload, self)
+            elif msg.type == aiohttp.WSMsgType.BINARY:
+                self.seen.append(decode_frame(msg.data))
+        return ws
+
+
+def _channel() -> str:
+    return base64.urlsafe_b64encode(secrets.token_bytes(16)).decode().rstrip("=")
+
+
+async def _serve(server):
+    app = web.Application()
+    app.router.add_get("/ws-cu", server.handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = runner.addresses[0][1]
+    return runner, f"ws://127.0.0.1:{port}/ws-cu"
+
+
+def _drive(server, body):
+    async def main():
+        runner, url = await _serve(server)
+        try:
+            return await body(url)
+        finally:
+            await runner.cleanup()
+
+    return asyncio.run(main())
+
+
+def test_exec_streams_output_and_exit_status():
+    async def script(ws, msg, gw):
+        if msg["type"] == "open":
+            ch = _channel()
+            gw.channel = ch
+            await ws.send_str(json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"}))
+            await ws.send_bytes(encode_frame(ch, b"out\n", STREAM_STDOUT))
+            await ws.send_bytes(encode_frame(ch, b"err\n", STREAM_STDERR))
+            await ws.send_str(json.dumps({"type": "exit", "channel": ch, "code": 3, "signal": None}))
+
+    server = FakeServer(script)
+
+    async def body(url):
+        from novem.code.compute import _exec_collect
+
+        async with ComputeConnection(url, "nut-secret") as conn:
+            assert conn.hello is not None
+            assert conn.hello.max_channels == 16
+            return await _exec_collect(conn, TARGET, "ls", ["-la"], "argv", "", None, 600)
+
+    result = _drive(server, body)
+
+    assert result.stdout == "out\n"
+    assert result.stderr == "err\n"
+    assert result.code == 3
+    assert result.ok is False
+
+    # the client authenticated with a bearer token and asked for the protocol,
+    # and never sent an Origin (self-asserted, so not trusted)
+    assert server.auth == "Bearer nut-secret"
+    assert server.subprotocol == PROTOCOL
+
+    opened = server.seen[0]
+    assert opened["kind"] == "exec"
+    assert opened["mode"] == "argv"
+    assert opened["command"] == "ls"
+    assert opened["args"] == ["-la"]
+    assert opened["target"] == TARGET
+    # stdin is closed explicitly rather than by closing the channel
+    assert {"type": "stdin_eof", "channel": server.channel} in server.seen
+
+
+def test_signalled_process_reports_signal():
+    async def script(ws, msg, gw):
+        if msg["type"] == "open":
+            ch = _channel()
+            await ws.send_str(json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"}))
+            # a signalled process carries -1 with a signal name
+            await ws.send_str(json.dumps({"type": "exit", "channel": ch, "code": -1, "signal": "TERM"}))
+
+    async def body(url):
+        from novem.code.compute import _exec_collect
+
+        async with ComputeConnection(url, "nut-x") as conn:
+            return await _exec_collect(conn, TARGET, "sleep", ["100"], "argv", "", None, 600)
+
+    result = _drive(FakeServer(script), body)
+    assert result.code == -1
+    assert result.signal == "TERM"
+    assert result.ok is False
+
+
+def test_error_before_ready_raises_with_stable_code():
+    async def script(ws, msg, gw):
+        if msg["type"] == "open":
+            await ws.send_str(
+                json.dumps(
+                    {
+                        "type": "error",
+                        "request_id": msg["request_id"],
+                        "code": "not_running",
+                        "message": "Computer connection could not be started",
+                    }
+                )
+            )
+
+    async def body(url):
+        async with ComputeConnection(url, "nut-x") as conn:
+            with pytest.raises(NovemComputeError) as ei:
+                await conn.open_exec(TARGET, "ls")
+            return ei.value
+
+    err = _drive(FakeServer(script), body)
+    assert err.code == "not_running"
+    assert err.retryable is True
+    assert "novem -c" in err.cli_message  # the hint tells you how to start it
+
+
+def test_not_found_never_claims_permission_denied():
+    async def script(ws, msg, gw):
+        if msg["type"] == "open":
+            await ws.send_str(
+                json.dumps(
+                    {
+                        "type": "error",
+                        "request_id": msg["request_id"],
+                        "code": "not_found",
+                        "message": "Computer was not found",
+                    }
+                )
+            )
+
+    async def body(url):
+        async with ComputeConnection(url, "nut-x") as conn:
+            with pytest.raises(NovemComputeError) as ei:
+                await conn.open_exec(TARGET, "ls")
+            return ei.value
+
+    err = _drive(FakeServer(script), body)
+    assert err.code == "not_found"
+    assert err.retryable is False
+    # a missing entitlement is indistinguishable from no access by design
+    assert "do not have access" in err.cli_message
+    assert "denied" not in err.cli_message.lower()
+
+
+def test_stdin_is_sent_before_eof():
+    async def script(ws, msg, gw):
+        if msg["type"] == "open":
+            ch = _channel()
+            gw.channel = ch
+            await ws.send_str(json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"}))
+            await ws.send_str(json.dumps({"type": "exit", "channel": ch, "code": 0, "signal": None}))
+
+    server = FakeServer(script)
+
+    async def body(url):
+        from novem.code.compute import _exec_collect
+
+        async with ComputeConnection(url, "nut-x") as conn:
+            return await _exec_collect(conn, TARGET, "wc", ["-l"], "argv", "", b"a\nb\n", 600)
+
+    _drive(server, body)
+
+    binary = [f for f in server.seen if isinstance(f, tuple)]
+    assert binary, "stdin should arrive as a binary frame"
+    stream, channel, payload = binary[0]
+    assert stream == 0  # clients may only send stream 0
+    assert payload == b"a\nb\n"
+
+
+def test_large_stdin_is_chunked_to_the_frame_limit():
+    async def script(ws, msg, gw):
+        if msg["type"] == "open":
+            ch = _channel()
+            await ws.send_str(json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": ch, "kind": "exec"}))
+            await ws.send_str(json.dumps({"type": "exit", "channel": ch, "code": 0, "signal": None}))
+
+    server = FakeServer(script)
+    blob = b"x" * (MAX_DATA_BYTES + 100)
+
+    async def body(url):
+        from novem.code.compute import _exec_collect
+
+        async with ComputeConnection(url, "nut-x") as conn:
+            return await _exec_collect(conn, TARGET, "cat", [], "argv", "", blob, 600)
+
+    _drive(server, body)
+
+    frames = [f for f in server.seen if isinstance(f, tuple)]
+    assert len(frames) == 2
+    assert len(frames[0][2]) == MAX_DATA_BYTES
+    assert len(frames[1][2]) == 100

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -7,8 +7,13 @@ dispatch without mocking the transport.
 
 import asyncio
 import base64
+import io
 import json
+import os
 import secrets
+import signal
+import sys
+import threading
 
 import aiohttp
 import pytest
@@ -19,11 +24,19 @@ from novem.code.compute import (
     PROTOCOL,
     STREAM_STDERR,
     STREAM_STDOUT,
+    Channel,
     ComputeConnection,
+    Hello,
     NovemComputeError,
+    NovemComputeTransportError,
     _exec_collect_channel,
+    _open_interactive_pty,
+    _pty_interactive,
+    _pump_stdin,
     _split_argv,
+    _use_channel_with_stdin,
     _with_retry,
+    _with_sigint_forwarding,
     decode_frame,
     encode_frame,
     target_for,
@@ -60,6 +73,8 @@ def test_ws_url_is_host_rooted():
     # /ws-cu is served at the host root, not under /v1
     assert ws_url("https://api.novem.io/v1/") == "wss://api.novem.io/ws-cu"
     assert ws_url("http://localhost:9090/v1/") == "ws://localhost:9090/ws-cu"
+    with pytest.raises(ValueError, match="scheme and host"):
+        ws_url("localhost:9090/v1/")
 
 
 def test_target_is_canonical():
@@ -90,35 +105,419 @@ def test_open_validation_matches_protocol_rules():
     asyncio.run(check())
 
 
+def test_unknown_error_codes_pass_through_as_terminal():
+    async def check():
+        conn = ComputeConnection("ws://unused/ws-cu", "nut-x")
+        fut = asyncio.get_running_loop().create_future()
+        conn._pending["np-future"] = fut
+
+        conn._on_text(
+            {
+                "type": "error",
+                "request_id": "np-future",
+                "code": "new_server_code",
+                "message": "A newer server reported an error",
+            }
+        )
+
+        with pytest.raises(NovemComputeError) as exc_info:
+            await fut
+        assert exc_info.value.code == "new_server_code"
+        assert exc_info.value.retryable is False
+        assert exc_info.value.cli_message == "A newer server reported an error"
+
+    asyncio.run(check())
+
+
+def test_unknown_or_invalid_ready_is_a_transport_error():
+    async def check():
+        unknown = ComputeConnection("ws://unused/ws-cu", "nut-x")
+        unknown._on_text({"type": "ready", "request_id": "not-pending", "channel": _channel(), "kind": "exec"})
+        assert isinstance(unknown._fatal, NovemComputeTransportError)
+        assert unknown._channels == {}
+
+        invalid = ComputeConnection("ws://unused/ws-cu", "nut-x")
+        future = asyncio.get_running_loop().create_future()
+        invalid._pending["np-pending"] = future
+        invalid._on_text({"type": "ready", "request_id": "np-pending", "kind": "exec"})
+        assert isinstance(invalid._fatal, NovemComputeTransportError)
+        assert invalid._channels == {}
+        with pytest.raises(NovemComputeTransportError):
+            await future
+
+    asyncio.run(check())
+
+
+@pytest.mark.parametrize(
+    ("close_code", "reason", "message"),
+    [
+        (1001, "session_ended", "session ended"),
+        (1008, "protocol_error", "Upgrade the CLI"),
+        (1011, "upstream_unavailable", "service ended"),
+        (1006, "connection_failed", "connection to the computer was lost"),
+    ],
+)
+def test_close_codes_map_to_distinct_transport_errors(close_code, reason, message):
+    class ClosedSocket:
+        def __init__(self):
+            self.close_code = close_code
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    async def check():
+        conn = ComputeConnection("ws://unused/ws-cu", "nut-x")
+        conn._ws = ClosedSocket()
+        await conn._read_loop()
+        assert isinstance(conn._fatal, NovemComputeTransportError)
+        assert conn._fatal.close_code == close_code
+        assert conn._fatal.code == reason
+        assert message in str(conn._fatal)
+
+    asyncio.run(check())
+
+
+def test_protocol_mismatch_cannot_complete_hello():
+    async def check():
+        conn = ComputeConnection("ws://unused/ws-cu", "nut-x")
+        conn._hello_event = asyncio.Event()
+        conn._on_text(
+            {
+                "type": "hello",
+                "protocol": "novem.compute.future",
+                "max_channels": 16,
+                "max_data_bytes": MAX_DATA_BYTES,
+                "heartbeat_seconds": 30,
+            }
+        )
+        with pytest.raises(NovemComputeTransportError, match="unexpected compute protocol"):
+            await conn._await_hello()
+
+    asyncio.run(check())
+
+
+def test_liveness_watchdog_fails_a_silent_connection():
+    class Socket:
+        def __init__(self):
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    async def check():
+        conn = ComputeConnection("ws://unused/ws-cu", "nut-x")
+        conn._ws = Socket()
+        conn.hello = Hello(PROTOCOL, 16, MAX_DATA_BYTES, 0.01)
+        conn._last_inbound = asyncio.get_running_loop().time() - 1
+        await asyncio.wait_for(conn._watch_liveness(), timeout=0.2)
+        assert isinstance(conn._fatal, NovemComputeTransportError)
+        assert conn._ws.closed is True
+
+    asyncio.run(check())
+
+
+def test_channel_honours_a_smaller_negotiated_frame_limit():
+    class Connection:
+        max_data_bytes = 4
+
+        def __init__(self):
+            self.frames = []
+
+        async def _send_binary(self, frame):
+            self.frames.append(frame)
+
+    async def check():
+        conn = Connection()
+        channel = Channel(conn, _channel(), "exec")
+        await channel.send(b"abcdefghij")
+        assert [decode_frame(frame)[2] for frame in conn.frames] == [b"abcd", b"efgh", b"ij"]
+
+    asyncio.run(check())
+
+
+def test_connection_enforces_and_releases_negotiated_channel_limit():
+    async def check():
+        conn = ComputeConnection("ws://unused/ws-cu", "nut-x")
+        conn.hello = Hello(PROTOCOL, 1, MAX_DATA_BYTES, 30)
+        channel_id = _channel()
+        conn._channels[channel_id] = Channel(conn, channel_id, "exec")
+
+        with pytest.raises(NovemComputeError) as exc_info:
+            await conn.open_exec(TARGET, "true")
+        assert exc_info.value.code == "limit_exceeded"
+
+        conn._on_text({"type": "exit", "channel": channel_id, "code": 0, "signal": None})
+        assert conn._channels == {}
+
+    asyncio.run(check())
+
+
+def test_file_stdin_preserves_arbitrary_bytes():
+    class RecordingChannel:
+        def __init__(self):
+            self.data = []
+            self.eof = False
+
+        async def send(self, data):
+            self.data.append(data)
+
+        async def stdin_eof(self):
+            self.eof = True
+
+    async def check():
+        channel = RecordingChannel()
+        await _pump_stdin(channel, io.BytesIO(b"\xff\xfe\x00\x80"))
+        assert b"".join(channel.data) == b"\xff\xfe\x00\x80"
+        assert channel.eof is True
+
+    asyncio.run(check())
+
+
+def test_pipe_stdin_sends_a_frame_before_writer_eof():
+    class RecordingChannel:
+        def __init__(self):
+            self.data = []
+            self.received = asyncio.Event()
+            self.eof = False
+
+        async def send(self, data):
+            self.data.append(data)
+            self.received.set()
+
+        async def stdin_eof(self):
+            self.eof = True
+
+    async def check():
+        read_fd, write_fd = os.pipe()
+        source = os.fdopen(read_fd, "rb", buffering=0)
+        channel = RecordingChannel()
+        try:
+            task = asyncio.create_task(_pump_stdin(channel, source))
+            os.write(write_fd, b"first chunk")
+            await asyncio.wait_for(channel.received.wait(), timeout=1)
+            assert task.done() is False
+            assert channel.data == [b"first chunk"]
+            os.close(write_fd)
+            write_fd = -1
+            await asyncio.wait_for(task, timeout=1)
+            assert channel.eof is True
+        finally:
+            source.close()
+            if write_fd >= 0:
+                os.close(write_fd)
+
+    asyncio.run(check())
+
+
+def test_output_is_consumed_while_file_stdin_is_still_open():
+    class BlockingInput:
+        def __init__(self):
+            self.started = threading.Event()
+            self.release = threading.Event()
+            self.complete = False
+
+        def read(self, size):
+            self.started.set()
+            self.release.wait(timeout=2)
+            if self.complete:
+                return b""
+            self.complete = True
+            return b"input"
+
+    class RecordingChannel:
+        def __init__(self):
+            self.data = []
+            self.eof = asyncio.Event()
+
+        async def send(self, data):
+            self.data.append(data)
+
+        async def stdin_eof(self):
+            self.eof.set()
+
+    async def check():
+        source = BlockingInput()
+        channel = RecordingChannel()
+        output_seen = asyncio.Event()
+
+        async def consume():
+            output_seen.set()
+            await channel.eof.wait()
+            return "done"
+
+        task = asyncio.create_task(_use_channel_with_stdin(channel, source, consume))
+        for _ in range(100):
+            if source.started.is_set():
+                break
+            await asyncio.sleep(0.001)
+        assert source.started.is_set()
+        await asyncio.wait_for(output_seen.wait(), timeout=0.1)
+        source.release.set()
+        assert await asyncio.wait_for(task, timeout=1) == "done"
+        assert channel.data == [b"input"]
+
+    asyncio.run(check())
+
+
+def test_first_sigint_is_forwarded_to_the_command(monkeypatch):
+    class RecordingChannel:
+        def __init__(self):
+            self.signals = []
+            self.forwarded = asyncio.Event()
+
+        async def signal(self, name):
+            self.signals.append(name)
+            self.forwarded.set()
+
+    async def check():
+        loop = asyncio.get_running_loop()
+        handlers = {}
+        monkeypatch.setattr(loop, "add_signal_handler", lambda sig, callback: handlers.setdefault(sig, callback))
+        monkeypatch.setattr(loop, "remove_signal_handler", lambda sig: handlers.pop(sig, None) is not None)
+        monkeypatch.setattr(signal, "getsignal", lambda sig: signal.default_int_handler)
+        monkeypatch.setattr(signal, "signal", lambda sig, handler: None)
+
+        channel = RecordingChannel()
+
+        async def command():
+            await channel.forwarded.wait()
+            return (0, "INT")
+
+        task = asyncio.create_task(_with_sigint_forwarding(channel, command))
+        for _ in range(100):
+            if signal.SIGINT in handlers:
+                break
+            await asyncio.sleep(0.001)
+        handlers[signal.SIGINT]()
+        assert await asyncio.wait_for(task, timeout=1) == (0, "INT")
+        assert channel.signals == ["INT"]
+
+    asyncio.run(check())
+
+
+@pytest.mark.skipif(os.name == "nt", reason="PTY handling is Unix-only")
+def test_open_pty_uses_stdin_for_size_and_has_a_fallback(monkeypatch):
+    class Stdin:
+        def isatty(self):
+            return True
+
+        def fileno(self):
+            return 42
+
+    class Connection:
+        async def open_pty(self, target, **kwargs):
+            self.target = target
+            self.kwargs = kwargs
+            return "channel"
+
+    seen = []
+
+    def no_size(fd):
+        seen.append(fd)
+        raise OSError("no terminal size")
+
+    monkeypatch.setattr(sys, "stdin", Stdin())
+    monkeypatch.setattr(os, "get_terminal_size", no_size)
+
+    async def check():
+        conn = Connection()
+        assert await _open_interactive_pty(conn, TARGET) == "channel"
+        assert conn.target == TARGET
+        assert conn.kwargs == {"rows": 24, "cols": 80}
+
+    asyncio.run(check())
+    assert seen == [42]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="PTY handling is Unix-only")
+def test_pty_hangup_sends_eof_once_without_spinning(monkeypatch):
+    import pty
+
+    class RecordingChannel:
+        def __init__(self):
+            self.eof_calls = 0
+            self.eof = asyncio.Event()
+
+        async def send(self, data):
+            pass
+
+        async def resize(self, rows, cols):
+            pass
+
+        async def stdin_eof(self):
+            self.eof_calls += 1
+            self.eof.set()
+
+        def __aiter__(self):
+            async def output():
+                await self.eof.wait()
+                if False:
+                    yield (0, b"")
+
+            return output()
+
+        async def wait(self):
+            return (0, None)
+
+    master_fd, slave_fd = pty.openpty()
+    stdin = os.fdopen(os.dup(slave_fd), "rb", buffering=0)
+    monkeypatch.setattr(sys, "stdin", stdin)
+
+    async def check():
+        channel = RecordingChannel()
+        task = asyncio.create_task(_pty_interactive(channel))
+        await asyncio.sleep(0.02)
+        os.close(master_fd)
+        assert await asyncio.wait_for(task, timeout=1) == (0, None)
+        assert channel.eof_calls == 1
+
+    try:
+        asyncio.run(check())
+    finally:
+        stdin.close()
+        os.close(slave_fd)
+
+
 # --- protocol, against a real server ----------------------------------------
 
 
 class FakeServer:
     """A minimal server-side implementation of novem.compute.v1."""
 
-    def __init__(self, script):
+    def __init__(self, script, *, reject_statuses=None, protocols=(PROTOCOL,), send_hello=True):
         self.script = script
         self.seen = []
         self.auth = None
         self.subprotocol = None
+        self.connections = 0
+        self.reject_statuses = list(reject_statuses or [])
+        self.protocols = protocols
+        self.send_hello = send_hello
 
     async def handler(self, request):
+        self.connections += 1
+        if self.reject_statuses:
+            return web.Response(status=self.reject_statuses.pop(0))
         self.auth = request.headers.get("Authorization")
         self.subprotocol = request.headers.get("Sec-WebSocket-Protocol")
-        ws = web.WebSocketResponse(protocols=(PROTOCOL,))
+        ws = web.WebSocketResponse(protocols=self.protocols)
         await ws.prepare(request)
 
-        await ws.send_str(
-            json.dumps(
-                {
-                    "type": "hello",
-                    "protocol": PROTOCOL,
-                    "max_channels": 16,
-                    "max_data_bytes": MAX_DATA_BYTES,
-                    "heartbeat_seconds": 30,
-                }
+        if self.send_hello:
+            await ws.send_str(
+                json.dumps(
+                    {
+                        "type": "hello",
+                        "protocol": PROTOCOL,
+                        "max_channels": 16,
+                        "max_data_bytes": MAX_DATA_BYTES,
+                        "heartbeat_seconds": 30,
+                    }
+                )
             )
-        )
 
         async for msg in ws:
             if msg.type == aiohttp.WSMsgType.TEXT:
@@ -248,7 +647,7 @@ def test_error_before_ready_raises_with_stable_code():
     assert "novem -c" in err.cli_message  # the hint tells you how to start it
 
 
-def test_retry_reopens_after_retryable_admission_error():
+def test_retry_reuses_connection_after_retryable_admission_error():
     attempts = 0
 
     async def script(ws, msg, server):
@@ -284,9 +683,67 @@ def test_retry_reopens_after_retryable_admission_error():
             1.0,
         )
 
-    result = _drive(FakeServer(script), body)
+    server = FakeServer(script)
+    result = _drive(server, body)
     assert result.code == 0
     assert attempts == 2
+    assert server.connections == 1
+
+
+def test_retryable_handshake_failure_reconnects_before_any_open():
+    async def script(ws, msg, server):
+        if msg["type"] != "open":
+            return
+        channel = _channel()
+        await ws.send_str(
+            json.dumps({"type": "ready", "request_id": msg["request_id"], "channel": channel, "kind": "exec"})
+        )
+        await ws.send_str(json.dumps({"type": "exit", "channel": channel, "code": 0, "signal": None}))
+
+    server = FakeServer(script, reject_statuses=[503])
+    retries = []
+
+    async def body(url):
+        return await _with_retry(
+            lambda conn: conn.open_exec(TARGET, "true"),
+            lambda channel: _exec_collect_channel(channel, None),
+            lambda: ComputeConnection(url, "nut-x"),
+            1.0,
+            retries.append,
+        )
+
+    result = _drive(server, body)
+    assert result.code == 0
+    assert server.connections == 2
+    assert len(retries) == 1
+    assert isinstance(retries[0], NovemComputeTransportError)
+    assert retries[0].code == "upstream_unavailable"
+
+
+def test_handshake_validation_failure_closes_all_resources(monkeypatch):
+    async def script(ws, msg, server):
+        pass
+
+    async def missing_protocol(url):
+        conn = ComputeConnection(url, "nut-x")
+        with pytest.raises(NovemComputeTransportError, match="negotiate"):
+            await conn.__aenter__()
+        assert conn._session.closed is True
+        assert conn._ws.closed is True
+
+    _drive(FakeServer(script, protocols=()), missing_protocol)
+
+    monkeypatch.setattr("novem.code.compute.HELLO_TIMEOUT_SECONDS", 0.05)
+
+    async def missing_hello(url):
+        conn = ComputeConnection(url, "nut-x")
+        with pytest.raises(NovemComputeTransportError, match="did not send hello"):
+            await conn.__aenter__()
+        assert conn._session.closed is True
+        assert conn._ws.closed is True
+        assert conn._reader.done() is True
+
+    _drive(FakeServer(script, send_hello=False), missing_hello)
 
 
 def test_retry_does_not_replay_a_command_after_ready():

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -435,6 +435,7 @@ def test_open_pty_uses_stdin_for_size_and_has_a_fallback(monkeypatch):
 @pytest.mark.skipif(os.name == "nt", reason="PTY handling is Unix-only")
 def test_pty_hangup_sends_eof_once_without_spinning(monkeypatch):
     import pty
+    import termios
 
     class RecordingChannel:
         def __init__(self):
@@ -465,6 +466,15 @@ def test_pty_hangup_sends_eof_once_without_spinning(monkeypatch):
     master_fd, slave_fd = pty.openpty()
     stdin = os.fdopen(os.dup(slave_fd), "rb", buffering=0)
     monkeypatch.setattr(sys, "stdin", stdin)
+
+    original_tcsetattr = termios.tcsetattr
+
+    def tcsetattr(fd, when, attributes):
+        if when == termios.TCSADRAIN:
+            raise termios.error(5, "Input/output error")
+        return original_tcsetattr(fd, when, attributes)
+
+    monkeypatch.setattr(termios, "tcsetattr", tcsetattr)
 
     async def check():
         channel = RecordingChannel()

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -185,6 +185,7 @@ def test_close_codes_map_to_distinct_transport_errors(close_code, reason, messag
         assert conn._fatal.close_code == close_code
         assert conn._fatal.code == reason
         assert message in str(conn._fatal)
+        assert conn._fatal.cli_message == str(conn._fatal)
 
     asyncio.run(check())
 
@@ -828,6 +829,24 @@ def test_429_handshake_exposes_retry_after_and_hint():
     assert "Wait briefly and try again" in error.cli_message
 
 
+def test_429_handshake_ignores_overflowing_retry_after():
+    async def script(ws, msg, server):
+        pass
+
+    server = FakeServer(script, reject_statuses=[(429, {"Retry-After": "9" * 309})])
+
+    async def body(url):
+        connection = ComputeConnection(url, "nut-x")
+        with pytest.raises(NovemComputeTransportError) as exc_info:
+            await connection.__aenter__()
+        return exc_info.value
+
+    error = _drive(server, body)
+    assert error.code == "limit_exceeded"
+    assert error.retryable is True
+    assert error.retry_after is None
+
+
 def test_retryable_transport_honours_retry_after(monkeypatch):
     attempts = 0
     waits = []
@@ -865,6 +884,41 @@ def test_retryable_transport_honours_retry_after(monkeypatch):
     assert result == "done"
     assert attempts == 2
     assert waits == [2.0]
+
+
+def test_retry_after_beyond_budget_fails_without_waiting(monkeypatch):
+    attempts = 0
+    waits = []
+    retries = []
+
+    class Context:
+        async def __aenter__(self):
+            nonlocal attempts
+            attempts += 1
+            raise NovemComputeTransportError(
+                "temporarily at capacity",
+                code="limit_exceeded",
+                retryable=True,
+                retry_after=120.0,
+            )
+
+        async def __aexit__(self, *exc):
+            pass
+
+    async def sleep(delay):
+        waits.append(delay)
+
+    async def unused(value):
+        raise AssertionError("no channel should open")
+
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+    with pytest.raises(NovemComputeTransportError) as exc_info:
+        asyncio.run(_with_retry(unused, unused, Context, 1.0, retries.append))
+
+    assert attempts == 1
+    assert waits == []
+    assert retries == []
+    assert "--connect-timeout" in exc_info.value.cli_message
 
 
 def test_handshake_validation_failure_closes_all_resources(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1300,6 +1300,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+compute = [
+    { name = "aiohttp" },
+]
 events = [
     { name = "python-socketio", extra = ["asyncio-client"] },
 ]
@@ -1326,6 +1329,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", marker = "extra == 'compute'", specifier = ">=3.9" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0,<2" },
     { name = "pyreadline3", marker = "os_name == 'nt'", specifier = ">=3.5.4" },
@@ -1334,7 +1338,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.14.1" },
     { name = "urllib3", specifier = ">=2.5.0" },
 ]
-provides-extras = ["events", "mcp"]
+provides-extras = ["events", "compute", "mcp"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1312,6 +1312,7 @@ mcp = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiohttp" },
     { name = "black" },
     { name = "flake8" },
     { name = "isort" },
@@ -1342,6 +1343,7 @@ provides-extras = ["events", "compute", "mcp"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiohttp", specifier = ">=3.9" },
     { name = "black", specifier = ">=24.8.0" },
     { name = "flake8", specifier = ">=7.1.1" },
     { name = "isort", specifier = ">=5.13.2,<9.0.0" },


### PR DESCRIPTION
Adds live connections to a running computer, plus a `novem.compute` client for them.

```bash
novem -c my-box -R -- ls -la /var/log   # run a command
novem -c my-box -A                      # interactive shell
cat data.csv | novem -c my-box -R -- wc -l
```

`-R` streams output as it arrives and exits with the command's own status (`128 + signal` when it was killed, the way a shell does). `-A` attaches a terminal with resize and signals wired through. Both wait while a computer finishes booting rather than failing immediately.

From the library:

```python
from novem import Computer

c = Computer("my-box")
res = c.run(["ls", "-la"], cwd="/home/user")   # buffered
code, signal = c.stream(["tail", "-f", "/var/log/app.log"])
c.shell()                                       # interactive
```

`Computer.connect()` exposes the connection directly for async callers who want to drive channels themselves.

### Also in this PR

- **`--image`** follows the same first-selector rule as the short flags: on its own it selects an image, once a resource is selected it sets that resource's image, and bare it reads the value back.
- **Job files move to `-i`/`-o`.** `-R @file` is gone — its slot belongs to run arguments, which are coming in a future release. On both flags an `@` prefix means one file and a bare path means a directory, and both repeat:
  ```bash
  novem -j my-job -R -i @prices.csv -i ./inputs -o @chart.png
  ```
  The old form errors with where to go rather than failing quietly.

### Notes

Live connections need the new optional `compute` extra (`pip install 'novem[compute]'`). Interactive shells are POSIX-only for now and say so on Windows.

Protocol tests run against a local WebSocket peer rather than a mock, covering the frame codec, message dispatch, exit and signal reporting, stdin chunking, and that an interrupted command is never replayed.
