### PR TITLE
ci: automate flake.lock updates

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,60 @@
+name: "Update flake.lock"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Monthly. `nix flake update` is all-or-nothing -- one PR moves every
+    # input -- and nixpkgs churns daily, so a weekly cadence would be noise.
+    - cron: "0 3 1 * *"
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    name: "Update flake.lock"
+    runs-on: ubuntu-latest
+    steps:
+    # The default GITHUB_TOKEN cannot open a PR that triggers workflows, so a
+    # flake.lock PR would sit without the Nix Checks run that justifies it.
+    # The app token opens PRs that do trigger CI.
+    - name: Generate GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        client-id: ${{ vars.GAIA_CI_CLIENT_ID }}
+        private-key: ${{ secrets.GAIA_CI_PRIVATE_KEY }}
+        # Narrow the token to what this job needs, rather than everything the
+        # installation grants.
+        permission-contents: write
+        permission-pull-requests: write
+        permission-issues: write
+
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        token: ${{ steps.app-token.outputs.token }}
+
+    # Same installer and pin as nix-build.yml, so dependabot tracks one action.
+    - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
+      with:
+        token: ${{ steps.app-token.outputs.token }}
+        commit-msg: "build(deps): update nix flake inputs"
+        pr-title: "build(deps): update nix flake inputs"
+        pr-labels: dependencies
+        # Attribute the commit to the app rather than github-actions[bot].
+        git-author-name: "gaia-ci[bot]"
+        git-author-email: "252333818+gaia-ci[bot]@users.noreply.github.com"
+        git-committer-name: "gaia-ci[bot]"
+        git-committer-email: "252333818+gaia-ci[bot]@users.noreply.github.com"
+        pr-body: |
+          Automated by [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock).
+
+          Dependabot has no Nix support, so `flake.lock` is updated here instead.
+
+          ```
+          {{ env.GIT_COMMIT_MESSAGE }}
+          ```


### PR DESCRIPTION
Dependabot has no Nix support, so `flake.lock` has been drifting unattended
since it was added. Current state on `main`:

| input | locked | age |
|---|---|---|
| nixpkgs | 2025-12-11 | 249d |
| uv2nix | 2025-12-13 | 247d |
| pyproject-nix | 2025-11-26 | 265d |
| pyproject-build-systems | 2025-11-20 | 270d |
| flake-utils | 2024-03-11 | 890d |
| systems | 2023-04-09 | 1227d |

`uv2nix` is the one that actually bites: it parses the `uv.lock` that
Dependabot now refreshes weekly. A 247-day-old uv2nix reading a freshly-bumped
lock doesn't fail loudly — it fails as a red `Nix Checks` on whatever unrelated
PR happens to be open.

## Verified before writing this

Ran the update locally and put the result through the same steps `nix-build.yml`
runs in CI:

```
nix flake update    all 5 inputs moved, nixpkgs 2025-12-11 -> 2026-08-16
nix build .#venv    pass
nix flake check     pass
nix build           pass
./result/bin/novem  pass
```

So the 249-day jump builds clean — the automation should produce mergeable PRs
rather than a standing red check.

## Why the Gaia CI app and not GITHUB_TOKEN

A PR opened with the default `GITHUB_TOKEN` does not trigger workflows. That
would leave every `flake.lock` PR sitting without the `Nix Checks` run that is
the entire reason for opening it — the action's own default PR body tells you to
close and re-open the PR by hand to work around this. An app token doesn't have
that limitation.

The token is narrowed via `permission-*` to contents, pull-requests and issues
(issues because PR labels go through the issues API). Gaia CI is deliberately
**not** granted `workflows: write`, so it cannot open a PR that edits CI —
that permission is write access to the CI execution environment, not just
slightly broader file access.

`vars.GAIA_CI_CLIENT_ID` and `secrets.GAIA_CI_PRIVATE_KEY` are already
installed on this repo, and I confirmed the installation grants
`contents:write`, `pull_requests:write` and `issues:write` by minting a test
token against it.

## Cadence

Monthly, not weekly. `nix flake update` is all-or-nothing — one PR moves every
input — so against a nixpkgs that churns daily, weekly would be pure noise for
no extra freshness.

## Proving it works

`workflow_dispatch` is wired up, so straight after merge:

```bash
gh workflow run "Update flake.lock" --repo novem-code/novem-python
```

That should open `build(deps): update nix flake inputs`, and that PR getting a
green `Nix Checks` is the real end-to-end proof — it validates the token, PR
creation, labelling, and that app-opened PRs trigger CI. It also lands the lock
update itself, so this PR deliberately does **not** include a hand-made
`flake.lock` change.

## Caveats

- **`workflow_dispatch` only appears once the file is on the default branch**,
  so this can't be tested before merging. First real run is post-merge on
  `main`. Failure is cheap and loud though — a red workflow run, no side
  effects, nothing half-applied.
- **v28 is unexercised.** My local test ran `nix flake update` directly, not
  through the action, so the dispatch run is the first thing that validates the
  pinned tag.
- **The lock it produces won't be byte-identical to what I tested** — nixpkgs
  moves daily, so a run today picks up something newer than `e5bdc4a4`. The
  green result above is strong evidence, not a guarantee; `Nix Checks` on the
  resulting PR is what confirms it.
- **v28 is 95 commits and ~9 months behind upstream `main`**, which is what
  upstream actually documents using (`@main`). I pinned the tag anyway, for the
  same reason we just pinned the PyPI publish action — an unpinned third-party
  action holding PR-write is a worse trade. Dependabot will offer v29 when it
  ships.
